### PR TITLE
Show live GitHub star count in nav

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -64,6 +64,9 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 .gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s;display:flex;align-items:center;gap:6px}
 .gh-link:hover{color:var(--text);border-color:var(--primary)}
 .gh-link svg{width:16px;height:16px;fill:currentColor}
+.gh-stars{font-size:.8rem;font-weight:700;color:var(--gold);display:none;align-items:center;gap:2px}
+.gh-stars::before{content:'\2605';font-size:.75rem}
+.gh-stars.loaded{display:inline-flex}
 
 .hero{text-align:center;padding:80px 24px 48px;position:relative;overflow:hidden}
 .hero::before{content:'';position:absolute;top:50%;left:50%;width:600px;height:600px;transform:translate(-50%,-60%);background:radial-gradient(circle,rgba(220,38,38,0.1) 0%,transparent 60%);pointer-events:none}
@@ -157,7 +160,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 </div>
 <div class="nav-actions">
 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">☾</button>
-<a href="https://github.com/rohitg00/awesome-openclaw" class="gh-link" target="_blank" rel="noopener"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a>
+<a href="https://github.com/rohitg00/awesome-openclaw" class="gh-link" target="_blank" rel="noopener"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-stars" id="ghStars"></span><span>GitHub</span></a>
 </div>
 </div>
 </nav>
@@ -1183,6 +1186,14 @@ const obs=new IntersectionObserver(entries=>{
 entries.forEach(e=>{if(e.isIntersecting){e.target.style.opacity='1';e.target.style.transform='translateY(0)'}});
 },{threshold:0.1});
 cards.forEach(c=>obs.observe(c));
+
+fetch('https://api.github.com/repos/rohitg00/awesome-openclaw')
+.then(r=>r.json()).then(d=>{
+if(d.stargazers_count!=null){
+const el=$('#ghStars');
+const n=d.stargazers_count>=1000?(d.stargazers_count/1000).toFixed(1)+'k':d.stargazers_count;
+el.textContent=n;el.classList.add('loaded');
+}}).catch(()=>{});
 })();
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 .gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s;display:flex;align-items:center;gap:6px}
 .gh-link:hover{color:var(--text);border-color:var(--primary)}
 .gh-link svg{width:16px;height:16px;fill:currentColor}
+.gh-stars{font-size:.8rem;font-weight:700;color:var(--gold, #F59E0B);display:none;align-items:center;gap:2px}
+.gh-stars::before{content:'\2605';font-size:.75rem}
+.gh-stars.loaded{display:inline-flex}
 .dir-link{color:var(--primary);text-decoration:none;font-size:.85rem;font-weight:600;padding:6px 14px;border-radius:8px;border:1px solid rgba(220,38,38,0.3);background:rgba(220,38,38,0.06);transition:all .2s;white-space:nowrap}
 .dir-link:hover{background:rgba(220,38,38,0.12);border-color:var(--primary)}
 .search-overlay{position:fixed;inset:0;z-index:200;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);display:none;align-items:flex-start;justify-content:center;padding-top:15vh}
@@ -197,7 +200,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <a href="directory.html" class="dir-link">Directory</a>
 <button class="search-btn" id="searchBtn"><svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"><circle cx="8.5" cy="8.5" r="5.5"/><path d="M13 13l4 4"/></svg><span class="label">Search</span><span class="kbd">&#8984;K</span></button>
 <button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
-<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span>GitHub</span></a>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-stars" id="ghStars"></span><span>GitHub</span></a>
 </div>
 </div></nav>
 
@@ -481,6 +484,14 @@ else if(e.key==='Enter'&&idx>=0){e.preventDefault();items[idx].click()}
 });
 
 loadReadme();
+
+fetch('https://api.github.com/repos/rohitg00/awesome-openclaw')
+.then(r=>r.json()).then(d=>{
+if(d.stargazers_count!=null){
+const el=$('#ghStars');
+const n=d.stargazers_count>=1000?(d.stargazers_count/1000).toFixed(1)+'k':d.stargazers_count;
+el.textContent=n;el.classList.add('loaded');
+}}).catch(()=>{});
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Fetches live star count from GitHub API on page load
- Displays gold star badge (e.g. `★ 2.3k`) next to the GitHub link in the nav bar
- Works on both index.html and directory.html
- Gracefully hidden if API call fails (no layout shift)

## Test plan
- [ ] Open both pages and verify star count appears next to GitHub icon
- [ ] Check mobile view — star count visible, no overflow
- [ ] Disable network — GitHub link still works, star badge just stays hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub repository star count display in the header next to the GitHub link. The count automatically updates on page load and displays in a readable format (e.g., 1.2k for counts ≥1,000).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->