### PR TITLE
Fix navbar getting cut off on mobile

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -128,10 +128,12 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 .hero p{font-size:.9rem;padding:0 8px}
 .hero-badge{font-size:.75rem;padding:4px 12px}
 .nav-links{display:none}
-.nav-inner{padding:0 12px}
-.gh-link span{display:none}
-.gh-link{padding:5px 10px}
-.theme-toggle{width:32px;height:32px;font-size:1rem}
+.nav-inner{padding:0 10px;gap:6px}
+.nav-actions{gap:6px}
+.gh-link{padding:4px 8px;gap:4px}
+.gh-link span:not(.gh-stars){display:none}
+.gh-stars.loaded{font-size:.7rem}
+.theme-toggle{width:30px;height:30px;font-size:.9rem}
 .section-title{font-size:1.2rem;padding:32px 16px 16px}
 .filters{justify-content:flex-start;overflow-x:auto;flex-wrap:nowrap;scrollbar-width:none;-webkit-overflow-scrolling:touch;padding:0 16px 16px}
 .filters::-webkit-scrollbar{display:none}

--- a/index.html
+++ b/index.html
@@ -167,13 +167,15 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 @keyframes spin{to{transform:rotate(360deg)}}
 @media(max-width:768px){
 .nav-links{display:none}
-.nav-inner{padding:0 12px}
-.dir-link{padding:5px 10px;font-size:.8rem}
-.search-btn{padding:5px 10px}
-.search-btn .label{display:none}
-.gh-link{padding:5px 10px}
-.gh-link span{display:none}
-.theme-toggle{width:32px;height:32px;font-size:1rem}
+.nav-inner{padding:0 10px;gap:6px}
+.nav-actions{gap:6px}
+.dir-link{padding:4px 8px;font-size:.75rem}
+.search-btn{padding:4px 8px;min-width:0}
+.search-btn .label,.search-btn .kbd{display:none}
+.gh-link{padding:4px 8px;gap:4px}
+.gh-link span:not(.gh-stars){display:none}
+.gh-stars.loaded{font-size:.7rem}
+.theme-toggle{width:30px;height:30px;font-size:.9rem}
 .hero{padding:60px 16px 40px}
 .hero h1{font-size:2rem}
 .hero-logo{max-width:200px}


### PR DESCRIPTION
## Summary
- Reduced nav-actions gap from 12px to 6px on mobile
- Compacted button padding (4px 8px) across all nav items
- Hidden text labels ("GitHub", "Search", keyboard shortcuts) while keeping icons and star count
- Applied to both index.html and directory.html

## Test plan
- [ ] Open on mobile — all nav items (Directory, Search, Theme, ★ GitHub) visible without overflow
- [ ] Verify star count still displays on mobile
- [ ] Check desktop layout is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined spacing and layout on mobile and tablet devices for improved usability and readability.
  * Optimized component sizing and typography across smaller viewports for better visual presentation.
  * Enhanced responsive design consistency throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->