### PR TITLE
Fix Moltbook URL to moltbook.com

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -199,7 +199,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <div class="card-header">
 <div class="card-icon">&#129438;</div>
 <div class="card-title-wrap">
-<div class="card-title"><a href="https://moltbookai.org" target="_blank" rel="noopener">Moltbook</a></div>
+<div class="card-title"><a href="https://www.moltbook.com/" target="_blank" rel="noopener">Moltbook</a></div>
 <div class="card-author">by Matt Schlicht</div>
 </div>
 </div>
@@ -207,7 +207,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <div class="card-meta">
 <span class="card-tag">Social</span>
 <span class="card-tag">AI Agents</span>
-<a href="https://moltbookai.org" class="card-link" target="_blank" rel="noopener">Visit &rarr;</a>
+<a href="https://www.moltbook.com/" class="card-link" target="_blank" rel="noopener">Visit &rarr;</a>
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Fixed Moltbook link from `moltbookai.org` (wrong) to `www.moltbook.com` (correct)
- Updated both the card title link and "Visit" link in directory.html