### PR TITLE
Hide hero CTA buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,8 +182,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 .hero-tagline{font-size:.95rem;padding:0 8px}
 .stats-bar{gap:12px}
 .stat{font-size:.85rem}
-.hero-ctas{flex-direction:column;align-items:center;gap:10px}
-.btn{width:100%;max-width:280px;justify-content:center;padding:12px 20px}
+.hero-ctas{display:none}
 .hero-badges{gap:4px}
 .hero-badges img{height:18px}
 .hero-search{margin-top:20px;padding:12px 16px;font-size:.85rem}


### PR DESCRIPTION
## Summary
- Hide "Join Discord" and "GitHub Repo" buttons on mobile (< 768px)
- Keeps the hero section clean on smaller screens — users already have the GitHub link in the nav