### PR TITLE
Add ClawdTalk — phone calling and SMS for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,10 +743,12 @@ ollama pull llama3.1
 | **OpenClaw Voice** | Self-hosted browser-based voice chat (Whisper STT + ElevenLabs TTS) |
 | **Android App** | Customizable wake words, long-press home button activation |
 | **Voice Call Plugin** | Telephony via Twilio, Telnyx, Plivo |
+| **ClawdTalk** | Phone calling and SMS for OpenClaw. Call your agent from any phone, with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx. |
 | **Always-On Speech** | macOS/iOS/Android with ElevenLabs |
 
 - [OpenClaw Voice](https://openclawvoice.com/)
 - [Voice Call Plugin Docs](https://docs.openclaw.ai/plugins/voice-call)
+- [ClawdTalk](https://clawdtalk.com/) — Phone calls and SMS for OpenClaw agents. Dedicated number, WebSocket client, agentic deep tools. ([GitHub](https://github.com/team-telnyx/clawdtalk-client) | [ClawHub](https://clawhub.ai/skills/clawdtalk-client))
 
 ### Home Automation
 

--- a/directory.html
+++ b/directory.html
@@ -1238,6 +1238,24 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 </div>
 </div>
 
+<div class="card" data-cat="voice" data-tier="a" style="animation-delay:1.88s">
+<div class="card-tier a">A</div>
+<div class="card-header">
+<div class="card-icon">&#128222;</div>
+<div class="card-title-wrap">
+<div class="card-title"><a href="https://clawdtalk.com" target="_blank" rel="noopener">ClawdTalk</a></div>
+<div class="card-author">by @team-telnyx</div>
+</div>
+</div>
+<div class="card-desc">Phone calling and SMS for OpenClaw. Call your agent from any phone with a dedicated number. Deep tool integration routes queries to your main agent session for calendar, Jira, web search, and more. Powered by Telnyx.</div>
+<div class="card-meta">
+<span class="card-tag">Voice</span>
+<span class="card-tag">SMS</span>
+<span class="card-tag">Telnyx</span>
+<span class="card-stars">&#9733; ClawHub</span>
+</div>
+</div>
+
 </div>
 <h2 class="section-title" id="knowledge-section">Memory &amp; Knowledge</h2>
 <div class="grid">


### PR DESCRIPTION
## What

Adds [ClawdTalk](https://clawdtalk.com) by Telnyx to the awesome list. ClawdTalk gives OpenClaw agents a phone number so users can call and text their agent from any phone.

## Features

- **Phone calls**: Call your OpenClaw agent, talk naturally, and it routes queries to your main agent session via deep tools (calendar, Jira, web search, messaging, etc.)
- **SMS**: Send and receive text messages through your agent's dedicated number
- **WebSocket client**: Maintains persistent connection to ClawdTalk server, handles call events and deep tool requests
- **ClawHub skill**: Install via clawdhub install clawdtalk-client

## Changes

- **README.md**: Added ClawdTalk to the Voice Assistant table and links section
- **directory.html**: Added ClawdTalk card in the Voice category (tier A)

## Links

- Website: https://clawdtalk.com
- GitHub: https://github.com/team-telnyx/clawdtalk-client
- ClawHub: https://clawhub.ai/skills/clawdtalk-client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ClawdTalk integration documentation featuring voice calling and SMS functionality for OpenClaw agents.
  * New directory entry includes capabilities for phone calls, SMS messaging, and tool integration with calendar, Jira, and web search via Telnyx.
  * ClawdTalk now available in Integrations & Features section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->