### PR TITLE
Add Clawd Arena to directory

### DIFF
--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -1786,6 +1786,23 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 </div>
 </div>
 
+<div class="card" data-cat="infra" data-tier="b" style="animation-delay:2.77s">
+<div class="card-tier b">B</div>
+<div class="card-header">
+<div class="card-icon">&#127942;</div>
+<div class="card-title-wrap">
+<div class="card-title"><a href="https://clawdarena.org/" target="_blank" rel="noopener">Clawd Arena</a></div>
+<div class="card-author">by @damoahdominic</div>
+</div>
+</div>
+<div class="card-desc">Community-driven leaderboard ranking 43+ OpenClaw hosting providers. Transparent voting, pricing comparison, and user reviews to help you pick the right host.</div>
+<div class="card-meta">
+<span class="card-tag">Hosting</span>
+<span class="card-tag">Leaderboard</span>
+<a href="https://clawdarena.org/" class="card-link" target="_blank" rel="noopener">Visit &rarr;</a>
+</div>
+</div>
+
 <div class="card" data-cat="automation" data-tier="b" style="animation-delay:2.78s">
 <div class="card-tier b">B</div>
 <div class="card-header">


### PR DESCRIPTION
## Summary
- Added [Clawd Arena](https://clawdarena.org/) to the Infrastructure & Deployment section
- Community-driven leaderboard ranking 43+ OpenClaw hosting providers with voting, pricing comparison, and user reviews
- Tier B, tagged with Hosting + Leaderboard

Closes #20

## Test plan
- [ ] Verify card renders correctly in the Infrastructure & Deployment section
- [ ] Verify link to clawdarena.org works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Clawd Arena to the Infrastructure & Deployment catalog, expanding the available infrastructure options with a new hosting and leaderboard solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->