### PR TITLE
Fix GitHub stars badge cut off on mobile

### DIFF
--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -129,8 +129,8 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 .hero-badge{font-size:.75rem;padding:4px 12px}
 .nav-links{display:none}
 .nav-inner{padding:0 10px;gap:6px}
-.nav-actions{gap:6px}
-.gh-link{padding:4px 8px;gap:4px}
+.nav-actions{gap:6px;flex-wrap:wrap}
+.gh-link{padding:4px 8px;gap:4px;flex-shrink:0;overflow:visible}
 .gh-link span:not(.gh-stars){display:none}
 .gh-stars.loaded{font-size:.7rem}
 .theme-toggle{width:30px;height:30px;font-size:.9rem}

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -178,11 +178,11 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 @media(max-width:768px){
 .sidebar{display:none}
 .nav-inner{padding:0 10px;gap:6px}
-.nav-actions{gap:6px}
+.nav-actions{gap:6px;flex-wrap:wrap}
 .dir-link{padding:4px 8px;font-size:.75rem}
 .search-btn{padding:4px 8px;min-width:0}
 .search-btn .label,.search-btn .kbd{display:none}
-.gh-link{padding:4px 8px;gap:4px}
+.gh-link{padding:4px 8px;gap:4px;flex-shrink:0;overflow:visible}
 .gh-link span:not(.gh-stars){display:none}
 .gh-stars.loaded{font-size:.7rem}
 .theme-toggle{width:30px;height:30px;font-size:.9rem}


### PR DESCRIPTION
## Summary
- Added `flex-shrink:0` and `overflow:visible` to `.gh-link` on mobile so the stars count doesn't get clipped by the flex container
- Added `flex-wrap:wrap` to `.nav-actions` on mobile to prevent overflow from cutting off elements
- Applied to both `index.html` and `directory.html` (the two pages that show stars)

## Test plan
- [ ] Check mobile view (~375px) — stars badge should be fully visible
- [ ] Check tablet view (~768px) — nav items shouldn't overflow
- [ ] Desktop view unchanged