### PR TITLE
Add security white paper, OpenClaw course, production use case, and MCP tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,12 +1012,11 @@ Capabilities: CDP, ARIA snapshots, screenshots, tab management, click/type/drag,
 - Voice notes to clean journal entries
 - Platform-specific content: X threads, LinkedIn posts, blog articles
 - Weekly meal planning in Notion (saves 1 hour/week)
+- **AI-Powered Daily Digest & Content Pipeline** — Production OpenClaw setup with 20+ cron jobs for automated news aggregation, multi-model content creation, social monitoring, and n8n webhook integration. Hosted on Oracle Cloud Free Tier. By Dr. Gaurav Caprihan.
 
 ### Family
 - Monitor school WhatsApp groups, filter noise
 - Run face recognition on photos, send daily digest to parents
-
-- **AI-Powered Daily Digest & Content Pipeline** — Production OpenClaw setup with 20+ cron jobs for automated news aggregation, multi-model content creation, social monitoring, and n8n webhook integration. Hosted on Oracle Cloud Free Tier. By [Dr. Gaurav Caprihan](https://gripsy.com.au/).
 
 - [25 OpenClaw Use Cases - Hostinger](https://www.hostinger.com/tutorials/openclaw-use-cases)
 - [20 Genius Use Cases](https://ucstrategies.com/news/20-genius-openclaw-use-cases-people-are-using-right-now/)
@@ -1050,7 +1049,6 @@ Capabilities: CDP, ARIA snapshots, screenshots, tab management, click/type/drag,
 - [Jitendra Zaa - Complete Guide](https://www.jitendrazaa.com/blog/ai/clawdbot-complete-guide-open-source-ai-assistant-2026/) — 147K+ stars overview, WhatsApp, API costs, skills
 - [AI/ML API - Practical Guide for Developers](https://aimlapi.com/blog/openclaw-a-practical-guide-to-local-ai-agents-for-developers) — Shift from chatbots to autonomous agents
 - [Pi: The Minimal Agent Within OpenClaw](https://lucumr.pocoo.org/2026/1/31/pi/) — Armin Ronacher's deep dive into Pi agent architecture
-- [Beyond Babel: Bridging AI's Communication Gap with MCP, A2A, and ACP](https://medium.com/@gaurav.caprihan/beyond-babel-bridging-ais-communication-gap-with-mcp-a2a-and-acp-35e348bb4233) — Deep analysis of AI agent interoperability protocols with practical MCP server integration using Melbourne open data. By Dr. Gaurav Caprihan.
 
 ### Reviews
 
@@ -1106,6 +1104,7 @@ Capabilities: CDP, ARIA snapshots, screenshots, tab management, click/type/drag,
 - [How Memory System Works](https://snowan.gitbook.io/study-notes/ai-blogs/openclaw-memory-system-deep-dive)
 - [centminmod/explain-openclaw](https://github.com/centminmod/explain-openclaw) - Multi-AI security analysis (73 files)
 - [Cron Jobs Automation Guide](https://zenvanriel.nl/ai-engineer-blog/openclaw-cron-jobs-proactive-ai-guide/)
+- [Beyond Babel: Bridging AI's Communication Gap with MCP, A2A, and ACP](https://medium.com/@gaurav.caprihan/beyond-babel-bridging-ais-communication-gap-with-mcp-a2a-and-acp-35e348bb4233) — Deep analysis of AI agent interoperability protocols with practical MCP server integration using Melbourne open data. By Dr. Gaurav Caprihan.
 
 ---
 


### PR DESCRIPTION
### What I'm adding

**4 resources from my production OpenClaw setup:**

1. **Security White Paper** (Security Resources) — n8n + OpenClaw integration security analysis covering credential isolation via n8n proxy, webhook hardening, and threat modeling. Peer-reviewed with multi-model validation.

2. **OpenClaw Mastery Course** (Courses & Learning) — 11-module interactive course on gripsy.com.au covering setup, skills, multi-model providers, security hardening, and automation. Includes quizzes and certificates.

3. **Production Use Case** (Real-World Use Cases) — 20+ automated cron jobs, multi-model content pipeline, daily digest system running on Oracle Cloud Free Tier with n8n webhook integration.

4. **MCP Protocol Tutorial** (Tutorials & Guides) — Published Medium article on AI agent interoperability (MCP, A2A, ACP) with working demo using Melbourne open data.

**About me:** Ph.D. in AI (1999), 25+ years in software engineering, running OpenClaw in production on Oracle Cloud Free Tier with n8n integration, multi-model providers, and automated content workflows.

Website: https://gripsy.com.au

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "n8n + OpenClaw Security White Paper" with security analysis and peer review notes
  * Added "Gripsy Learn – OpenClaw Mastery" course to learning platforms
  * Added "Beyond Babel: Bridging AI's Communication Gap with MCP, A2A, and ACP" as deep dive (appears in Tutorials & Guides and Deep Dives)
  * Added "AI-Powered Daily Digest & Content Pipeline" as a new capability and real-world use case
<!-- end of auto-generated comment: release notes by coderabbit.ai -->