### PR TITLE
Fix anchor link scroll to top on page load

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -328,6 +328,10 @@ postProcess(mainContent);
 buildNav(mainContent);
 initScrollReveal();
 indexSearch();
+if(window.location.hash){
+const target=document.getElementById(window.location.hash.slice(1));
+if(target)setTimeout(()=>target.scrollIntoView({behavior:'smooth',block:'start'}),100);
+}
 }catch(e){
 console.error('Failed to load README:',e);
 $('#mainContent').innerHTML='<p style="text-align:center;padding:40px;color:var(--text-muted)">Failed to load content. <a href="https://github.com/rohitg00/awesome-openclaw/blob/main/README.md">View README on GitHub</a></p>';


### PR DESCRIPTION
## Summary
- Fixed section anchor links (e.g. `#security--hardening`) scrolling to the top of the page instead of the target section
- Root cause: heading IDs are created dynamically after async fetch of README.md, so the browser's native hash scroll fires before the target element exists
- Added `window.location.hash` check after content loads to scroll to the correct section

## Test plan
- [ ] Open `https://openclawsearch.com/#security--hardening` — should scroll to Security section
- [ ] Open `https://openclawsearch.com/#quick-start-1-minute` — should scroll to Quick Start section
- [ ] Open `https://openclawsearch.com/` (no hash) — should load normally at top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hash-based in-page navigation. URLs with anchors now automatically scroll to the corresponding sections upon page load, enabling direct navigation to specific content areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->