### PR TITLE
Add Hire nav link to all pages

### DIFF
--- a/docs/blog/blog.html
+++ b/docs/blog/blog.html
@@ -112,6 +112,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <a href="/" class="nav-link">Home</a>
 <a href="/directory" class="nav-link">Directory</a>
 <a href="/blog" class="nav-link active">Blog</a>
+<a href="https://hire.openclawsearch.com" class="nav-link" target="_blank" rel="noopener noreferrer">Hire</a>
 <button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">&#x263E;</span></button>
 <a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span>GitHub</span></a>
 </div>

--- a/docs/blog/token-optimization.html
+++ b/docs/blog/token-optimization.html
@@ -221,6 +221,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <a href="/" class="nav-link">Home</a>
 <a href="/directory" class="nav-link">Directory</a>
 <a href="/blog" class="nav-link active">Blog</a>
+<a href="https://hire.openclawsearch.com" class="nav-link" target="_blank" rel="noopener noreferrer">Hire</a>
 <button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">&#x263E;</span></button>
 <a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span>GitHub</span></a>
 </div>

--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -162,6 +162,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 </div>
 <div class="nav-actions">
 <a href="/blog" class="back-link">Blog</a>
+<a href="https://hire.openclawsearch.com" class="back-link" target="_blank" rel="noopener noreferrer">Hire</a>
 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">☾</button>
 <a href="https://github.com/rohitg00/awesome-openclaw" class="gh-link" target="_blank" rel="noopener"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-stars" id="ghStars"></span><span>GitHub</span></a>
 </div>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -209,6 +209,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <div class="nav-actions">
 <a href="/directory" class="dir-link">Directory</a>
 <a href="/blog" class="dir-link">Blog</a>
+<a href="https://hire.openclawsearch.com" class="dir-link" target="_blank" rel="noopener noreferrer">Hire</a>
 <button class="search-btn" id="searchBtn"><svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"><circle cx="8.5" cy="8.5" r="5.5"/><path d="M13 13l4 4"/></svg><span class="label">Search</span><span class="kbd">&#8984;K</span></button>
 <button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
 <a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="gh-stars" id="ghStars"></span><span>GitHub</span></a>


### PR DESCRIPTION
## Summary
- Adds "Hire" navigation link to index.html, directory.html, and blog.html
- Links point to `https://hire.openclawsearch.com` (the new OpenClaw Hire platform)
- Styled consistently with existing nav patterns on each page (dir-link, back-link, nav-link)

## Test plan
- [ ] Verify Hire link appears in nav on Home page
- [ ] Verify Hire link appears in nav on Directory page
- [ ] Verify Hire link appears in nav on Blog page
- [ ] Verify links point to correct URL
- [ ] Check mobile responsiveness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Hire" external navigation link (opens in a new tab) across multiple site pages to provide a direct hiring entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->