### PR TITLE
Add AfrexAI Skills to Notable Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,8 +990,8 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **Unbrowse** | Self-learning API skill generator — auto-discovers APIs from browser traffic, 100x faster than browser automation | [GitHub](https://github.com/lekt9/unbrowse-openclaw) |
 | **Foundry** | Self-writing meta-extension — learns how you work, researches docs, writes new capabilities into itself | [GitHub](https://github.com/lekt9/openclaw-foundry) |
 | **Supermemory (Official)** | Official Supermemory integration — perfect memory and recall, auto-stores conversations | [GitHub](https://github.com/supermemoryai/openclaw-supermemory) |
-
 | **AfrexAI Skills** | 13 free business skills: prospect research, cold email, competitor analysis, meeting prep, LinkedIn, ICP builder, CRM, invoicing, SEO, daily briefing, objection handling, email triage, humanizer | [Setup Wizard](https://afrexai-cto.github.io/agent-setup/) \| [Revenue Calculator](https://afrexai-cto.github.io/ai-revenue-calculator/) \| [Context Packs](https://afrexai-cto.github.io/context-packs/) |
+
 ### Third-Party Platforms
 
 | Platform | Integration | Description |


### PR DESCRIPTION
## What

Adds AfrexAI to the Notable Skills & Plugins table.

## AfrexAI Skills

13 free OpenClaw/ClawHub skills for business automation:
- Prospect Researcher
- Cold Email Writer
- Competitor Analyst
- Meeting Prep
- LinkedIn Writer
- ICP Builder
- CRM Manager
- Invoice Generator
- SEO Writer
- Daily Briefing
- Objection Handler
- Email Triager
- Humanizer

Also includes:
- [AI Revenue Calculator](https://afrexai-cto.github.io/ai-revenue-calculator/)
- [Agent Setup Wizard](https://afrexai-cto.github.io/agent-setup/)
- [Context Packs Store](https://afrexai-cto.github.io/context-packs/)

All tools are free and open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Notable Skills & Plugins section to include AfrexAI Skills, adding a collection of 13 free business skills with related reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->