### PR TITLE
feat: Add clawtick.com cloud scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ Full suite access: Gmail, Calendar, Drive, Docs, Sheets. All data stays local â€
 - [Webhooks Docs](https://docs.openclaw.ai/automation/webhook)
 - [Cron Jobs Docs](https://docs.openclaw.ai/automation/cron-jobs)
 - [Heartbeat Docs](https://docs.openclaw.ai/gateway/heartbeat)
-- **[ClawTick](https://clawtick.com/)**: A cloud scheduler for OpenClaw agents.
+- **[ClawTick](https://clawtick.com/)**: A cloud scheduler for OpenClaw agents. ([GitHub](https://github.com/abakermi/clawtick))
 
 ### Live Canvas
 


### PR DESCRIPTION
Adds clawtick.com, a cloud scheduler for OpenClaw agents, to the awesome list under the Webhooks & Cron Jobs section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ClawTick documentation in the Webhooks & Cron Jobs section, detailing its cloud scheduler capabilities for OpenClaw agents
  * Updated the Monitoring & Dashboards section with ClawTick, describing its performance monitoring, uptime checks, and real-time analytics features for OpenClaw instances

<!-- end of auto-generated comment: release notes by coderabbit.ai -->