### PR TITLE
Add PinchChat to Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,7 +1384,7 @@ node --version                     # Must be 22+
 | [freema/openclaw-mcp](https://github.com/freema/openclaw-mcp) | MCP server bridging Claude.ai to self-hosted OpenClaw with OAuth 2.1 authentication |
 | [beam-cloud/airstore](https://github.com/beam-cloud/airstore) | The filesystem for AI agents — persistent agent storage layer (89 stars) |
 | [sseanliu/VisionClaw](https://github.com/sseanliu/VisionClaw) | Real-time AI assistant for Meta Ray-Ban smart glasses — voice + vision + agentic actions, iOS/Swift (796 stars) |
-| **[PinchChat](https://github.com/MarlBurroW/pinchchat)** | Web (PWA) | Available | Open-source webchat UI with ChatGPT-like interface, live tool calls, multi-session, token tracking, streaming, 8 languages, theming |
+| [MarlBurroW/pinchchat](https://github.com/MarlBurroW/pinchchat) | Open-source webchat UI for OpenClaw — ChatGPT-like interface, live tool calls, multi-session, token tracking, streaming, PWA, 8 languages, theming |
 | [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw) | Original NanoClaw — 500 lines TypeScript, Apple containers for security, WhatsApp, Anthropic Agent SDK (7K+ stars) |
 | [SeyZ/clawbands](https://github.com/SeyZ/clawbands) | Security middleware — intercepts tool execution, human-in-the-loop approval for dangerous actions |
 | [newtro/ClawGuard](https://github.com/newtro/ClawGuard) | Permission manifests, runtime enforcement, sandboxing, and audit logging for OpenClaw skills |


### PR DESCRIPTION
Adding PinchChat, an open-source webchat UI for OpenClaw.

https://github.com/MarlBurroW/pinchchat

ChatGPT-like interface with live tool call visualization, multi-session management, token usage tracking, streaming, inline images, PWA support, 8 languages, and theming. React + Vite + Tailwind, Docker image on ghcr.io. MIT licensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PinchChat entries to the README across Companion Apps, Monitoring & Dashboards, and Alternatives & Competitors.
  * Documented PinchChat as a Web PWA with live tool calls, multi-session support, streaming/token tracking, 8-language support, and customizable theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->