### PR TITLE
Update README: Kimi Claw, ZeroClaw, TinyClaw, v2026.2.12, latest stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ That's it. The wizard walks you through API key setup, channel configuration, an
 | **[Docker](https://docs.openclaw.ai/docker)** | 5 min | Medium | Isolation & reproducibility |
 | **[Cloudflare Workers](https://docs.openclaw.ai/cloudflare)** | 5 min | Medium | Serverless enthusiasts |
 | **[xCloud Managed](https://xcloud.host/openclaw-hosting)** | 5 min | None | Full managed hosting |
+| **[Kimi Claw](https://kimi.com/bot)** | Instant | None | Browser-native OpenClaw in kimi.com, 5K+ skills, 40 GB storage |
 | **[Molty by Finna](https://molty.finna.ai)** | 30 sec | None | Multiple Molties, Mission Control, GitHub sync |
 | **[Manual VPS](https://docs.openclaw.ai/vps)** | 10 min | Medium | Full control |
 | **[Raspberry Pi](https://docs.openclaw.ai/raspberry-pi)** | 10 min | Medium | Low-power, always-on |
@@ -310,6 +311,7 @@ These providers handle ALL the setup for you — no Docker, no terminal, no DevO
 | **[SimpleClaw](https://www.simpleclaw.com/)** | TBD | < 1 min | Managed | 1-click deploy, model selection | - |
 | **[OpenClaw Cloud](https://openclawcloud.work/)** | Beta pricing | 5 min | Managed | All AI tokens included, 99.9% uptime, $0 hidden fees | Waitlist open |
 | **[OpenClawd.ai](https://openclawd.ai)** | Free + Premium | Minutes | Managed | Launched Feb 10 — fully managed hosting, one-click deploy, security built-in, free tier available | - |
+| **[Kimi Claw](https://kimi.com/bot)** | Allegretto+ | Instant | Browser-native | OpenClaw native in kimi.com — 5,000+ ClawHub skills, 40 GB cloud storage, Yahoo Finance search, BYOC (Bring Your Own Claw) | Beta open |
 | **[Kilo Claw](https://kilo.ai/kiloclaw)** | Pay-as-you-go | < 60 sec | Managed | 500+ models, 50+ platforms, SSO, audit logs | 7 days free compute |
 | **[OpenClaw Hosting](https://openclawhosting.io/pricing)** | $29+ | 5 min | Managed | Solo/Team/Business tiers, annual billing saves 20% | - |
 | **[Myclawhost](https://www.myclawhost.com/)** | $9-39 | Instant | Managed | Lite ($9), Pro ($19), Max ($39), full lifecycle | One-click deploy |


### PR DESCRIPTION
## Summary

### New Projects Added
- **Kimi Claw** — Browser-native OpenClaw on kimi.com, 5K+ ClawHub skills, 40GB cloud storage, Yahoo Finance search, BYOC (Bring Your Own Claw), beta open for Allegretto+
- **ZeroClaw** — Pure Rust, 3.4 MB binary, <10ms startup, 22+ providers, swappable trait architecture
- **TinyClaw** — OpenClaw in ~400 LoC shell script, Claude Code + tmux, self-healing (1.3K stars)
- **Mini-Claw** — Minimalist alternative using Claude Pro/Max or ChatGPT Plus directly in Telegram

### New Security Tools
- **Clawhatch** — Pre-install security scanner, 128 checks, scores 0-100
- **OpenClaw Scanner** — Enterprise endpoint detection for OpenClaw agents
- **Semgrep** — OpenClaw Security Engineer's Cheat Sheet

### Updated Stats
- Exposed instances: 30K → **135K+** (Censys/Bitsight)
- PicoClaw stars: 2.1K → **5K**
- Contributors: 380+ → **600+**
- Main repo stars: 176K+ → **195K+**
- IronClaw: Added **1.3K stars** count

### New Release
- **v2026.2.12** (Feb 12) — 40+ security patches, SSRF/prompt injection fixes
- Updated security notice to **v2026.2.12+**

### New Integration Guides
- 5 Kimi K2.5 integration tutorials (Medium, Apidog, Moonshot, Baseten, Fireworks AI)
- Updated Kimi K2.5 as free built-in provider since v2026.2.6

### Updated Entries
- **OpenClawd.ai** — Feb 10 launch, free + premium pricing

## Test plan

- [ ] Verify all markdown table formatting renders correctly
- [ ] Confirm new GitHub links are valid
- [ ] Check website auto-renders at openclawsearch.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new setup methods: Kimi Claw, ZeroClaw, TinyClaw
  * Expanded hosting and managed service offerings
  * Updated pricing comparison table with new providers
  * Added Semgrep security guide reference
  * Released v2026.2.12 with security fixes
  * Updated contributor counts to 600+
  * Expanded global adoption and ecosystem coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->