### PR TITLE
Add ClawLaunch to Managed Hosting Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ These providers handle ALL the setup for you — no Docker, no terminal, no DevO
 | **[Myclawhost](https://www.myclawhost.com/)** | $9-39 | Instant | Managed | Lite ($9), Pro ($19), Max ($39), full lifecycle | One-click deploy |
 | **[Contabo OpenClaw](https://contabo.com/en/openclaw-hosting/)** | $4.95+ | Minutes | VPS | Unlimited workflows, full data ownership, predictable pricing | - |
 | **[Molty by Finna](https://molty.finna.ai)** | $19-99 | 30 sec | VM-isolated (Fly.io) | Multiple Molties per account, Mission Control (multi-agent coordination), GitHub backup sync, browser automation, auto-updates | 3-day free trial |
+| **[ClawLaunch](https://clawlaunch.ai)** | Free (30d) / $9.49 | 60 sec | Varies by plan | Includes AI Credits. Hardened sandbox via gVisor. Free TTS pre-installed (Whisper). | 30-day free trial, 50% revshare affiliate program |
 
 ### Setup-as-a-Service (Freelancers)
 


### PR DESCRIPTION
## Add ClawLaunch to Managed Hosting Services

Hey @rohitg00 👋

I'm the founder of [ClawLaunch](https://clawlaunch.ai) and would like to add it the Managed Hosting Services table.

### What is ClawLaunch?

ClawLaunch is a managed OpenClaw hosting provider focused on security and simplicity:

- **Free 30-day trial**, no credit card needed
- **$9.49/mo** after trial (500 Telegram Stars)
- **Hardened sandbox via gVisor** for safer agent execution
- **AI credits included** so you can get started without your own API keys
- **Free TTS pre-installed (Whisper)** for voice out of the box
- **60-second setup**, fully managed, no DevOps

### Affiliate Program

We also have a **50% revenue share affiliate program**. You can generate your own affiliate link through our Telegram bot at [t.me/clawlaunch_ai_bot](https://t.me/clawlaunch_ai_bot) (check bot profile to set it up).

Happy to tweak the entry if needed. Thanks for putting this list together! 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new hosting provider to the comparison tables in the README with details on pricing, setup time, plan variability, included features (AI credits, gVisor sandbox, free TTS), 30-day free trial, and affiliate program benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->