### PR TITLE
Add memory-mem0 self-hosted memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **Claude Team** | Spawns visible terminal sessions instead of background | [X/@jlehman_](https://x.com/jlehman_/status/2008644506951053492) |
 | **ClawRouter** | Smart LLM router — save 78% on inference costs, 30+ models | [GitHub](https://github.com/BlockRunAI/ClawRouter) |
 | **Honcho** | Persistent cross-session memory with user modeling and dual-peer context | [ClawHub](https://clawhub.ai/ajspig/honcho-setup) \| [GitHub](https://github.com/plastic-labs/openclaw-honcho/tree/main/clawhub/honcho-setup) |
+| **memory-mem0** | Self-hosted memory plugin using Mem0 for semantic fact extraction. Local Ollama embeddings, Qdrant vector storage, Gemini Flash extraction. | [GitHub](https://github.com/serenichron/openclaw-memory-mem0) |
 | **Agent Sessions** | Session browser + analytics + limits tracker for Codex CLI, Claude Code, OpenCode, Gemini CLI (245 stars) | [GitHub](https://github.com/jazzyalex/agent-sessions) |
 | **Announcer** | House-wide TTS announcements via AirPlay speakers | [GitHub](https://github.com/odrobnik/announcer-skill) |
 | **GitHub Search Skills** | Deep GitHub project analysis and exploration | [GitHub](https://github.com/blessonism/openclaw-search-skills) |


### PR DESCRIPTION
Adds memory-mem0: a self-hosted OpenClaw memory plugin backed by Mem0 REST API.\n\nHighlights:\n- Semantic fact extraction via Mem0 + Gemini Flash\n- Local Ollama embeddings\n- Qdrant vector storage\n- Drop-in LanceDB replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added memory-mem0 plugin entry to the Skills & Plugins section, documenting a self-hosted memory solution featuring Mem0 with Ollama embeddings and Qdrant vector storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->