### PR TITLE
feat: add botemail.ai - email inboxes for OpenClaw agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ ollama pull llama3.1
 - **Google Calendar**: Event creation, viewing, sync, daily briefings
 - **Apple Calendar**: Via khal/vdirsyncer integration
 - **Outlook**: Calendar sync and management
+- **[BotEmail.ai](https://botemail.ai)** — Instant @botemail.ai email inboxes for AI agents. One API call creates a dedicated inbox with no human setup required. Includes an OpenClaw skill ([ClawHub](https://clawhub.ai/skills/bot-email)), MCP server, and OpenAI GPT Actions support.
 
 - [Gmail Automation Guide](https://zenvanriel.nl/ai-engineer-blog/openclaw-gmail-pubsub-automation-guide/)
 - [Google Calendar Sync](https://martin.hjartmyr.se/articles/openclaw-google-calendar-sync/)


### PR DESCRIPTION
Adds **[BotEmail.ai](https://botemail.ai)** to the Email & Calendar section under Integrations & Features.

BotEmail.ai provides instant @botemail.ai email inboxes for AI agents. One API call creates a dedicated inbox with no human setup required. It integrates natively with OpenClaw via a published ClawHub skill, and also supports MCP server and OpenAI GPT Actions.

- ?? Website: https://botemail.ai
- ?? OpenClaw skill: https://clawhub.ai/skills/bot-email
- ??? MCP server available
- ?? OpenAI GPT Actions support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added BotEmail.ai to the Email & Calendar section with details and reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->