### PR TITLE
Add Nerve — self-hosted web cockpit for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Studio](https://github.com/grp06/openclaw-studio)** | Community | Visual agent management with cron jobs, tool extraction, mentions (410 stars) |
 | **[Hawk Eye](https://github.com/benfoxsb/hawk-eye)** | Community | Workspace sentinel & operational dashboard |
 | **[ClawTick](https://clawtick.com/)** | Third-party | Performance monitoring, uptime checks, and real-time analytics for OpenClaw instances. |
-| **[Nerve](https://github.com/daggerhashimoto/openclaw-nerve)** | Community | Self-hosted web cockpit for OpenClaw — real-time streaming with reasoning blocks, voice I/O (local STT/TTS), sub-agent session monitoring, cron job management, memory editor, inline TradingView/Recharts, code editor, model selector. One-command install. [Website](https://nerve.zone) |
+| **[Nerve](https://github.com/daggerhashimoto/openclaw-nerve)** ([Website](https://nerve.zone)) | Community | Web-based OpenClaw cockpit with real-time streaming, voice I/O, and agent management |
 
 ### Backup & Restore
 

--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Studio](https://github.com/grp06/openclaw-studio)** | Community | Visual agent management with cron jobs, tool extraction, mentions (410 stars) |
 | **[Hawk Eye](https://github.com/benfoxsb/hawk-eye)** | Community | Workspace sentinel & operational dashboard |
 | **[ClawTick](https://clawtick.com/)** | Third-party | Performance monitoring, uptime checks, and real-time analytics for OpenClaw instances. |
+| **[Nerve](https://github.com/daggerhashimoto/openclaw-nerve)** | Community | Self-hosted web cockpit for OpenClaw — real-time streaming with reasoning blocks, voice I/O (local STT/TTS), sub-agent session monitoring, cron job management, memory editor, inline TradingView/Recharts, code editor, model selector. One-command install. [Website](https://nerve.zone) |
 
 ### Backup & Restore
 


### PR DESCRIPTION
Adds [Nerve](https://github.com/daggerhashimoto/openclaw-nerve) to the Monitoring & Dashboards section.

Nerve is a self-hosted web dashboard for managing OpenClaw agents. Features include real-time chat streaming with reasoning blocks, voice I/O with local STT/TTS, sub-agent session monitoring, cron job management, a memory editor, inline TradingView/Recharts rendering, a code editor, and per-session model selection.

- **GitHub:** https://github.com/daggerhashimoto/openclaw-nerve
- **Website:** https://nerve.zone
- **License:** MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Community entry for Nerve in Monitoring & Dashboards, linking to its website and describing it as a web-based OpenClaw cockpit with real-time streaming, voice I/O, and agent management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->