### PR TITLE
Add clawr.ing to Voice Assistant section

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,13 +778,13 @@ ollama pull llama3.1
 | **Android App** | Customizable wake words, long-press home button activation |
 | **Voice Call Plugin** | Telephony via Twilio, Telnyx, Plivo |
 | **ClawdTalk** | Phone calling and SMS for OpenClaw. Call your agent from any phone, with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx. |
-| **[clawr.ing](https://clawr.ing)** | Your bot gets a real phone and calls you. Wake-up calls, reminders, alerts with two-way voice conversations. 70+ voices, 100+ countries. |
+| **[clawr.ing](https://clawr.ing)** | Your bot gets a real phone and calls you. Wake-up calls, reminders, alerts with two-way voice conversations. |
 | **Always-On Speech** | macOS/iOS/Android with ElevenLabs |
 
 - [OpenClaw Voice](https://openclawvoice.com/)
 - [Voice Call Plugin Docs](https://docs.openclaw.ai/plugins/voice-call)
 - [ClawdTalk](https://clawdtalk.com/) — Phone calls and SMS for OpenClaw agents. Dedicated number, WebSocket client, agentic deep tools. ([GitHub](https://github.com/team-telnyx/clawdtalk-client) | [ClawHub](https://clawhub.ai/skills/clawdtalk-client))
-- [clawr.ing](https://clawr.ing) — Your bot calls you. Two-way voice conversations with 70+ voices, 100+ countries. ([ClawHub](https://clawhub.ai/marcospgp/clawring))
+- [clawr.ing](https://clawr.ing) — Your bot calls you. Wake-up calls, reminders, alerts with two-way voice. ([ClawHub](https://clawhub.ai/marcospgp/clawring))
 
 ### Home Automation
 

--- a/README.md
+++ b/README.md
@@ -778,11 +778,13 @@ ollama pull llama3.1
 | **Android App** | Customizable wake words, long-press home button activation |
 | **Voice Call Plugin** | Telephony via Twilio, Telnyx, Plivo |
 | **ClawdTalk** | Phone calling and SMS for OpenClaw. Call your agent from any phone, with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx. |
+| **[clawr.ing](https://clawr.ing)** | Your bot gets a real phone and calls you. Wake-up calls, reminders, alerts with two-way voice conversations. 70+ voices, 100+ countries. |
 | **Always-On Speech** | macOS/iOS/Android with ElevenLabs |
 
 - [OpenClaw Voice](https://openclawvoice.com/)
 - [Voice Call Plugin Docs](https://docs.openclaw.ai/plugins/voice-call)
 - [ClawdTalk](https://clawdtalk.com/) — Phone calls and SMS for OpenClaw agents. Dedicated number, WebSocket client, agentic deep tools. ([GitHub](https://github.com/team-telnyx/clawdtalk-client) | [ClawHub](https://clawhub.ai/skills/clawdtalk-client))
+- [clawr.ing](https://clawr.ing) — Your bot calls you. Two-way voice conversations with 70+ voices, 100+ countries. ([ClawHub](https://clawhub.ai/marcospgp/clawring))
 
 ### Home Automation
 


### PR DESCRIPTION
Adds [clawr.ing](https://clawr.ing) to the Voice Assistant table and links section.

clawr.ing is a phone calling skill for OpenClaw. Your bot gets a real phone and calls you for wake-up calls, reminders, and alerts with two-way voice conversations. 70+ voices, 100+ countries.

Unlike ClawdTalk (inbound: call your agent from a phone), clawr.ing is outbound: your agent calls you when something matters.

Also published on [ClawHub](https://clawhub.ai/marcospgp/clawring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation and a Resources link for the clawr.ing integration describing real phone calls (wake-up calls, reminders, alerts) with two-way voice conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->