### PR TITLE
Add discourse-openclaw plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **QMD Skill** | Cuts token usage by 95% | [X/@milesdeutscher](https://x.com/milesdeutscher/status/2018768974872449100) |
 | **Supermemory** | Unlimited memory for OpenClaw | ClawHub |
 | **Cognee** | Graph-based memory with auto-recall, semantic search | [GitHub](https://github.com/topoteretes/cognee-integrations/tree/main/integrations/openclaw) \| [npm](https://www.npmjs.com/package/@cognee/cognee-openclaw) |
+| **Discourse** | Discourse forum integration — read, search, filter, and write topics/posts via agent tools | [GitHub](https://github.com/pranciskus/discourse-openclaw) \| [npm](https://www.npmjs.com/package/openclaw-discourse) |
 | **Claude Team** | Spawns visible terminal sessions instead of background | [X/@jlehman_](https://x.com/jlehman_/status/2008644506951053492) |
 | **ClawRouter** | Smart LLM router — save 78% on inference costs, 30+ models | [GitHub](https://github.com/BlockRunAI/ClawRouter) |
 | **Honcho** | Persistent cross-session memory with user modeling and dual-peer context | [ClawHub](https://clawhub.ai/ajspig/honcho-setup) \| [GitHub](https://github.com/plastic-labs/openclaw-honcho/tree/main/clawhub/honcho-setup) |


### PR DESCRIPTION
## Summary
- Adds [discourse-openclaw](https://github.com/pranciskus/discourse-openclaw) to the **Notable Skills & Plugins** table
- The plugin provides Discourse forum integration for OpenClaw — read, search, filter, and write topics/posts via agent tools
- Available on [npm](https://www.npmjs.com/package/openclaw-discourse) and GitHub

## Test plan
- [ ] Verify the table row renders correctly in the README
- [ ] Confirm the GitHub and npm links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Discourse skill entry to the Skills documentation. The entry describes a forum integration capability enabling users to read, search, filter, and write topics and posts through agent tools. Documentation includes direct links to the GitHub repository and npm package for implementation guidance and additional technical resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->