### PR TITLE
Add SwarmClaw to Related Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ node --version                     # Must be 22+
 | [BankrBot/openclaw-skills](https://github.com/BankrBot/openclaw-skills) | DeFi/crypto skill library — Polymarket, token trading, NFTs, on-chain messaging |
 | [clawd800/pumpclaw](https://github.com/clawd800/pumpclaw) | Token launcher for AI agents on Base — Uniswap V4 pools, on-chain registry, CLI and Farcaster deploy bot |
 | [SamurAIGPT/awesome-openclaw](https://github.com/SamurAIGPT/awesome-openclaw) | Community-curated list of OpenClaw resources, tools, and tutorials |
+| [swarmclawai/swarmclaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted AI agent orchestration dashboard with multi-provider support, task scheduling, and per-agent OpenClaw gateway bridging |
 | [nearai/private-ml-sdk](https://github.com/nearai/private-ml-sdk) | Run LLMs and agents on TEEs (NVIDIA GPU TEE, Intel TDX) for private inference |
 | [eltociear/awesome-molt-ecosystem](https://github.com/eltociear/awesome-molt-ecosystem) | Curated list of Molt ecosystem services — Moltbook, MoltCities, Molthunt, MoltMatch |
 | [kelkalot/moltbook-observatory](https://github.com/kelkalot/moltbook-observatory) | Data collection from Moltbook — tracking agents, posts, and trends over time |


### PR DESCRIPTION
  ## Summary
  This PR adds [swarmclawai/swarmclaw](https://github.com/
  swarmclawai/swarmclaw) to the **Related Repositories**
  table in `README.md`.

  ## Why
  SwarmClaw is an OpenClaw-inspired, self-hosted agent
  orchestration project and fits this repo’s ecosystem/
  repository listings.

  ## Change
  - Added one new row:
    - `swarmclawai/swarmclaw` — Self-hosted AI agent
  orchestration dashboard with multi-provider support,
  task scheduling, and per-agent OpenClaw gateway
  bridging.

  ## Scope
  - Documentation-only change
  - No code/runtime changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the ecosystem resources list with a new entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->