### PR TITLE
Add TryOpenClaw to managed hosting services

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ These providers handle ALL the setup for you — no Docker, no terminal, no DevO
 | **[Contabo OpenClaw](https://contabo.com/en/openclaw-hosting/)** | $4.95+ | Minutes | VPS | Unlimited workflows, full data ownership, predictable pricing | - |
 | **[Molty by Finna](https://molty.finna.ai)** | $19-99 | 30 sec | VM-isolated (Fly.io) | Multiple Molties per account, Mission Control (multi-agent coordination), GitHub backup sync, browser automation, auto-updates | 3-day free trial |
 | **[ClawLaunch](https://clawlaunch.ai)** | Free (30d) / $9.49 | 60 sec | Varies by plan | Includes AI Credits. Hardened sandbox via gVisor. Free TTS pre-installed (Whisper). | 30-day free trial, 50% revshare affiliate program |
-| **[OpenClaw Setup](https://openclaw-setup.me)** | $3.9 (Solo) / $6.9 (Trio) | ~2 min | 1 CPU, 3-12 GB RAM | Full UI instance management (LLM providers, env vars, workspace and memory management), Telegram + Slack support, encrypted credentials, allowlist access control, per-model usage analytics | AWESOMEOPENCLAWSETUP (50% off first-time customers) | | **[TryOpenClaw](https://www.tryopenclaw.ai)** | $1 | 60 sec | Managed | Chat with OpenClaw in 60 seconds — pick WhatsApp/Telegram/Discord/Slack/iMessage, no setup needed. | - |
+| **[OpenClaw Setup](https://openclaw-setup.me)** | $3.9 (Solo) / $6.9 (Trio) | ~2 min | 1 CPU, 3-12 GB RAM | Full UI instance management (LLM providers, env vars, workspace and memory management), Telegram + Slack support, encrypted credentials, allowlist access control, per-model usage analytics | AWESOMEOPENCLAWSETUP (50% off first-time customers) |
+| **[TryOpenClaw](https://www.tryopenclaw.ai)** | $1 | 60 sec | Managed | Chat with OpenClaw in 60 seconds — pick WhatsApp/Telegram/Discord/Slack/iMessage, no setup needed. | - |
 
 ### Setup-as-a-Service (Freelancers)
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ These providers handle ALL the setup for you — no Docker, no terminal, no DevO
 | **[Contabo OpenClaw](https://contabo.com/en/openclaw-hosting/)** | $4.95+ | Minutes | VPS | Unlimited workflows, full data ownership, predictable pricing | - |
 | **[Molty by Finna](https://molty.finna.ai)** | $19-99 | 30 sec | VM-isolated (Fly.io) | Multiple Molties per account, Mission Control (multi-agent coordination), GitHub backup sync, browser automation, auto-updates | 3-day free trial |
 | **[ClawLaunch](https://clawlaunch.ai)** | Free (30d) / $9.49 | 60 sec | Varies by plan | Includes AI Credits. Hardened sandbox via gVisor. Free TTS pre-installed (Whisper). | 30-day free trial, 50% revshare affiliate program |
-| **[OpenClaw Setup](https://openclaw-setup.me)** | $3.9 (Solo) / $6.9 (Trio) | ~2 min | 1 CPU, 3-12 GB RAM | Full UI instance management (LLM providers, env vars, workspace and memory management), Telegram + Slack support, encrypted credentials, allowlist access control, per-model usage analytics | AWESOMEOPENCLAWSETUP (50% off first-time customers) |
+| **[OpenClaw Setup](https://openclaw-setup.me)** | $3.9 (Solo) / $6.9 (Trio) | ~2 min | 1 CPU, 3-12 GB RAM | Full UI instance management (LLM providers, env vars, workspace and memory management), Telegram + Slack support, encrypted credentials, allowlist access control, per-model usage analytics | AWESOMEOPENCLAWSETUP (50% off first-time customers) | | **[TryOpenClaw](https://www.tryopenclaw.ai)** | $1 | 60 sec | Managed | Chat with OpenClaw in 60 seconds — pick WhatsApp/Telegram/Discord/Slack/iMessage, no setup needed. | - |
 
 ### Setup-as-a-Service (Freelancers)
 


### PR DESCRIPTION
Adds TryOpenClaw (https://www.tryopenclaw.ai) to the Managed Hosting Services table. TryOpenClaw is a hosted OpenClaw service where users can get their own AI assistant running in 60 seconds for $1, supporting WhatsApp, Telegram, Discord, Slack, and iMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TryOpenClaw to the Managed Hosting Services table (listed price, setup time, specs and brief description).
  * Added TryOpenClaw as a provider in the Setup-as-a-Service (Freelancers) section with matching pricing, setup details and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->