### PR TITLE
Add feishu-inout: Lark/Feishu docs, messaging, calendar & bitable skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **memory-mem0** | Self-hosted memory plugin using Mem0 for semantic fact extraction. Local Ollama embeddings, Qdrant vector storage, Gemini Flash extraction. | [GitHub](https://github.com/serenichron/openclaw-memory-mem0) |
 | **Agent Sessions** | Session browser + analytics + limits tracker for Codex CLI, Claude Code, OpenCode, Gemini CLI (245 stars) | [GitHub](https://github.com/jazzyalex/agent-sessions) |
 | **Announcer** | House-wide TTS announcements via AirPlay speakers | [GitHub](https://github.com/odrobnik/announcer-skill) |
+| **feishu-inout** | Lark/Feishu docs, messaging, calendar & bitable integration for AI coding agents. Zero dependencies, official MCP. | [GitHub](https://github.com/joe960913/feishu-inout) |
 | **GitHub Search Skills** | Deep GitHub project analysis and exploration | [GitHub](https://github.com/blessonism/openclaw-search-skills) |
 | **Unbrowse** | Self-learning API skill generator — auto-discovers APIs from browser traffic, 100x faster than browser automation | [GitHub](https://github.com/lekt9/unbrowse-openclaw) |
 | **Foundry** | Self-writing meta-extension — learns how you work, researches docs, writes new capabilities into itself | [GitHub](https://github.com/lekt9/openclaw-foundry) |


### PR DESCRIPTION
## feishu-inout

One command to connect AI coding agents to Lark (Feishu) — docs, messaging, calendar, bitable.

- 📄 Read/write/search cloud documents (7 edit modes)
- 💬 Send/read/search messages (user identity, no bot needed)
- 📅 Create calendar events with auto video meeting
- 📊 CRUD bitable records
- 👥 Create groups and add members
- Zero dependencies, official MCP + Open API

**Repo:** https://github.com/joe960913/feishu-inout
**Install:** `npx skills add joe960913/feishu-inout`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added feishu-inout entry to Notable Skills & Plugins table, documenting Lark/Feishu integration capabilities for document, messaging, calendar, and bitable features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->