### PR TITLE
Add awesome-openclaw-personas to Related Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ node --version                     # Must be 22+
 | [BankrBot/openclaw-skills](https://github.com/BankrBot/openclaw-skills) | DeFi/crypto skill library — Polymarket, token trading, NFTs, on-chain messaging |
 | [clawd800/pumpclaw](https://github.com/clawd800/pumpclaw) | Token launcher for AI agents on Base — Uniswap V4 pools, on-chain registry, CLI and Farcaster deploy bot |
 | [SamurAIGPT/awesome-openclaw](https://github.com/SamurAIGPT/awesome-openclaw) | Community-curated list of OpenClaw resources, tools, and tutorials |
+| [TravisLeeeeee/awesome-openclaw-personas](https://github.com/TravisLeeeeee/awesome-openclaw-personas) | 214+ production-ready persona packages across 34 categories (SOUL.md + AGENTS.md + SKILL.md) |
 | [nearai/private-ml-sdk](https://github.com/nearai/private-ml-sdk) | Run LLMs and agents on TEEs (NVIDIA GPU TEE, Intel TDX) for private inference |
 | [eltociear/awesome-molt-ecosystem](https://github.com/eltociear/awesome-molt-ecosystem) | Curated list of Molt ecosystem services — Moltbook, MoltCities, Molthunt, MoltMatch |
 | [kelkalot/moltbook-observatory](https://github.com/kelkalot/moltbook-observatory) | Data collection from Moltbook — tracking agents, posts, and trends over time |


### PR DESCRIPTION
Hi! I maintain [awesome-openclaw-personas](https://github.com/TravisLeeeeee/awesome-openclaw-personas) — a curated, open-source collection of **214+ production-ready OpenClaw persona packages** across **34 categories** (e-commerce, marketing, finance, engineering, game dev, etc.).

Unlike single-file SOUL.md templates, each persona is a **complete multi-file package** (SOUL.md + AGENTS.md + SKILL.md + optional files) with real methodology, SOPs, and deliverable templates.

The collection is updated weekly and sourced from the broader OpenClaw community including GitHub repos, ClawHub, and Claw Mart-inspired configurations.

Repo: https://github.com/TravisLeeeeee/awesome-openclaw-personas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new related repository reference, highlighting 214+ production-ready persona packages across 34 categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->