### PR TITLE
Add prompt-to-asset and unslop to Notable Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,8 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **Cognee** | Graph-based memory with auto-recall, semantic search | [GitHub](https://github.com/topoteretes/cognee-integrations/tree/main/integrations/openclaw) \| [npm](https://www.npmjs.com/package/@cognee/cognee-openclaw) |
 | **Claude Team** | Spawns visible terminal sessions instead of background | [X/@jlehman_](https://x.com/jlehman_/status/2008644506951053492) |
 | **ClawRouter** | Smart LLM router — save 78% on inference costs, 30+ models | [GitHub](https://github.com/BlockRunAI/ClawRouter) |
+| **prompt-to-asset** | Image-generation router — send prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney) through a single MCP interface | [GitHub](https://github.com/MohamedAbdallah-14/prompt-to-asset) \| [npm](https://www.npmjs.com/package/prompt-to-asset) |
+| **unslop** | CLI that strips AI writing patterns from output — removes LLM filler and passive hedges before publishing | [GitHub](https://github.com/MohamedAbdallah-14/unslop) \| [npm](https://www.npmjs.com/package/unslop) |
 | **Honcho** | Persistent cross-session memory with user modeling and dual-peer context | [ClawHub](https://clawhub.ai/ajspig/honcho-setup) \| [GitHub](https://github.com/plastic-labs/openclaw-honcho/tree/main/clawhub/honcho-setup) |
 | **memory-mem0** | Self-hosted memory plugin using Mem0 for semantic fact extraction. Local Ollama embeddings, Qdrant vector storage, Gemini Flash extraction. | [GitHub](https://github.com/serenichron/openclaw-memory-mem0) |
 | **Agent Sessions** | Session browser + analytics + limits tracker for Codex CLI, Claude Code, OpenCode, Gemini CLI (245 stars) | [GitHub](https://github.com/jazzyalex/agent-sessions) |


### PR DESCRIPTION
## Add prompt-to-asset and unslop to Notable Skills & Plugins

Two tools that fit alongside ClawRouter in the Notable Skills & Plugins section.

**[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** — Image-generation router: routes prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney) through a single MCP interface. Same idea as ClawRouter but for image generation instead of LLM routing. `npm install -g prompt-to-asset`

**[unslop](https://github.com/MohamedAbdallah-14/unslop)** — CLI that strips AI writing patterns from output. Removes LLM filler phrases and passive hedges before publishing to docs or READMEs. `npm install -g unslop`

Both are on npm. Placed in Notable Skills & Plugins after ClawRouter since they're similar router/utility tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended the Notable Skills & Plugins list with two new third-party integrations: `prompt-to-asset` and `unslop`, including documentation and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->