### PR TITLE
Add Onepilot to Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[VisionClaw](https://github.com/sseanliu/VisionClaw)** | Meta Ray-Ban (iOS) | Available | Voice + vision + agentic actions via Gemini Live + OpenClaw (796 stars) |
 | **[PinchChat](https://github.com/MarlBurroW/pinchchat)** | Web (PWA) | Available | Open-source webchat UI with ChatGPT-like interface, live tool calls, multi-session, token tracking, streaming, 8 languages, theming |
 | **[VibeClaw](https://vibeclaw.dev)** | Web | Available | Runs a full OpenClaw instance entirely in the browser — visual server builder, in-browser sandbox with free AI models, server library with import/export. No install, no server required ([source](https://github.com/jasonkneen/vibeclaw)) |
+| **[Onepilot](https://onepilotapp.com)** | iOS/iPadOS | Available | SSH client that deploys, runs, and chats with OpenClaw agents on a remote machine. Also supports Hermes, Claude Code, and Codex CLI. |
 
 ### Monitoring & Dashboards
 


### PR DESCRIPTION
Adding Onepilot to Companion Apps.

Onepilot is an iOS and iPadOS SSH client for running OpenClaw, Hermes, and other terminal coding agents on a remote machine. https://onepilotapp.com

Entry placed alongside other mobile and platform-specific clients and matches existing format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded companion apps documentation with Onepilot, an iOS/iPadOS SSH client enabling users to deploy, manage, and interact with agents from mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->