### PR TITLE
docs: expand March OpenClaw workflow blog posts

### DIFF
--- a/docs/blog/codex-app-server-over-chat.html
+++ b/docs/blog/codex-app-server-over-chat.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Codex Workflows Moved Into Telegram and Discord</title>
-<meta name="description" content="OpenClaw Codex App Server shows the next developer workflow: coding agents controlled from chat, not just terminals.">
+<meta name="description" content="A practical look at the OpenClaw Codex App Server bridge: chat as control plane, thread binding, permissions, and compatibility discipline.">
 <meta property="og:title" content="Codex Workflows Moved Into Telegram and Discord">
-<meta property="og:description" content="OpenClaw Codex App Server shows the next developer workflow: coding agents controlled from chat, not just terminals.">
+<meta property="og:description" content="A practical look at the OpenClaw Codex App Server bridge: chat as control plane, thread binding, permissions, and compatibility discipline.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/codex-app-server-over-chat">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Codex Workflows Moved Into Telegram and Discord">
-<meta name="twitter:description" content="OpenClaw Codex App Server shows the next developer workflow: coding agents controlled from chat, not just terminals.">
+<meta name="twitter:description" content="A practical look at the OpenClaw Codex App Server bridge: chat as control plane, thread binding, permissions, and compatibility discipline.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,11 +134,11 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Dev Tools</div>
 <h1 class="article-title">Codex Workflows Moved Into Telegram and Discord</h1>
-<p class="article-subtitle">OpenClaw Codex App Server shows the next developer workflow: coding agents controlled from chat, not just terminals.</p>
+<p class="article-subtitle">The useful pattern is not chatting with a coding agent. It is binding a chat to a real Codex thread with visible controls, stop buttons, and version-aware operating notes.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Mar 13, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Builder/operator analysis</span>
 <span>Week of Mar 10, 2026</span>
 </div>
 <div class="article-pills">
@@ -147,223 +147,50 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">ChatOps</span>
 </div>
 </header>
+
 <div class="callout callout-info">
 <div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 10, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<p>This March post covers a third-party OpenClaw workflow source, not a core OpenClaw release. The source is <a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener">pwrdrvr/openclaw-codex-app-server</a>, a TypeScript plugin for connecting OpenClaw chat channels to the Codex App Server protocol.</p>
 </div>
-<h2>The short version</h2>
-<p>
-The Codex App Server signal is that coding work is moving out of a single local prompt box and into chat-native workflows where humans can assign, observe, and review tasks asynchronously.
-</p>
-<p>
-The public source I am using here is pwrdrvr/openclaw-codex-app-server.
-OpenClaw plugin that brings Codex to Telegram and Discord via the Codex App Server protocol.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The mistake is to think the interface is the product.
-Telegram and Discord are not magic.
-The product is the workflow around them: who can ask, what can be changed, what evidence is returned, and how the change is reviewed.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>pwrdrvr/openclaw-codex-app-server</td></tr>
-<tr><td>Created</td><td>2026-03-13</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>243</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
+<h2>The real signal: chat became the control plane</h2>
+<p>The interesting part of <code>openclaw-codex-app-server</code> is not that someone put another bot in Telegram or Discord. That part is easy to overhype. The useful signal is narrower: developer agents are starting to need a shared control plane where a human can resume an existing coding thread, change model and reasoning settings, stop a run, compact context, and keep the conversation attached to a real project.</p>
+<p>The repository describes itself carefully: an independent OpenClaw plugin that connects to the Codex App Server protocol so Telegram and Discord conversations can interact with existing Codex Desktop and Codex TUI threads. It explicitly says it is not official, sponsored, endorsed, or affiliated with OpenAI or Codex. That disclaimer matters. The project is a bridge, not a platform announcement.</p>
+<div class="table-wrap"><table><thead><tr><th>What to inspect</th><th>Why it matters</th></tr></thead><tbody>
+<tr><td>Thread binding</td><td>A chat must map to one Codex thread; otherwise replies become ambiguous and unsafe.</td></tr>
+<tr><td>Project and thread pickers</td><td>Ambiguous commands should show choices instead of guessing which repo to touch.</td></tr>
+<tr><td>Stop / compact / permissions controls</td><td>Agent runs need interruption and context management, not just a text box.</td></tr>
+<tr><td>Local Codex CLI dependency</td><td>The plugin inherits local login state and machine permissions from the host.</td></tr>
+<tr><td>Unsafe install flag</td><td>OpenClaw flags it because it launches <code>codex app-server</code>; that is a real operational boundary.</td></tr>
+</tbody></table></div>
+<h2>Why this is more than a novelty integration</h2>
+<p>A coding agent in a terminal is a single-user tool. A coding agent reachable from Telegram or Discord becomes an operating workflow. That changes the failure modes. You now have channel membership, message routing, stale threads, permission prompts, hidden local state, and the risk that someone assumes the bot is safer because the interface feels casual.</p>
+<p>The plugin's README is useful because it does not hide the mechanics. The normal flow is: install the plugin, open the target chat, run <code>/cas_resume</code>, pick a recent thread or start a new one, then send plain text into that bound thread. That is the right shape for an operator-facing tool: explicit bind first, plain-language work second.</p>
+<h2>The compatibility lesson was immediate</h2>
+<p>This plugin is also a good example of why March OpenClaw content should talk about versions. The repository documents compatibility across OpenClaw <code>2026.3.22+</code>, <code>2026.3.31+</code>, <code>v2026.4.2</code>, and later local checkouts. It mentions the Telegram runtime/outbound adapter split, generated Discord and Telegram facades, and a period where <code>plugins update</code> could not accept the unsafe-install flag.</p>
+<p>That is not incidental housekeeping. It is the cost of building against a moving agent runtime. If an integration touches channel SDKs, process spawning, local credentials, and interactive buttons, it needs a compatibility table. Without one, users will blame OpenClaw, Codex, Telegram, Discord, and the plugin in random order when something breaks.</p>
+<div class="callout callout-tip"><div class="callout-title">Operator read</div><p>Do not evaluate this pattern by asking, “Can I chat with Codex?” Evaluate it by asking, “Can I prove which thread is bound, which project is active, which permissions are enabled, and how I stop the run?”</p></div>
+<h2>Where the pattern is strong</h2>
+<ul>
+<li><strong>Asynchronous review:</strong> a maintainer can hand a thread a small task from mobile, then inspect the resulting diff later.</li>
+<li><strong>Shared visibility:</strong> a team channel can see task intent, model choices, and high-level status instead of a private terminal session.</li>
+<li><strong>Thread continuity:</strong> resuming existing Codex Desktop/TUI threads avoids losing context when work moves between interfaces.</li>
+<li><strong>Explicit controls:</strong> model switching, fast mode, permissions mode, stop buttons, and compaction are the controls real users need after the demo.</li>
+</ul>
+<h2>Where I would be cautious</h2>
+<p>Chat interfaces make dangerous actions feel lightweight. A message like “fix the auth bug” can imply reading secrets, editing code, running tests, and creating branches. If the host machine's Codex CLI is already authenticated and has repo access, the plugin is operating inside that trust boundary. That is useful, but it is not harmless.</p>
+<p>For production use I would want a narrow allowlist of repositories, a clear mapping from channel to project, logs for every command sent to Codex, and a documented policy for when the agent may write, run tests, or request elevated permission. I would also keep merge authority outside the chat bridge. Chat should queue and supervise work; the repository should remain the review boundary.</p>
+<div class="checklist"><h3>Adoption checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Pin plugin and OpenClaw versions before adding it to a team channel.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Confirm the local <code>codex</code> CLI works and understand which account it uses.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Create a test chat and verify bind, resume, stop, compact, and permission flows.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Document who can invoke the bot and which repositories it may touch.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Require branch/PR review for any file-changing work.</span></div>
 </div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-A good chat-controlled coding agent should create a branch, explain its plan, run checks, link the diff, and stop before merging.
-That is the minimum shape of trust.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-If a chat agent cannot show the command it ran, the files it touched, and the tests it executed, it should not be allowed near a real repo.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The durable pattern is “chat as request queue, repo as source of truth, PR as review boundary.”
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-Codex Workflows Moved Into Telegram and Discord is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener">
-<div class="source-title">pwrdrvr/openclaw-codex-app-server</div>
-<div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div>
-</a>
-</div>
+<h2>The practical takeaway</h2>
+<p>The durable OpenClaw pattern here is “chat as request queue, local agent server as executor, repo as source of truth, PR as review boundary.” Telegram and Discord are not the product. The product is the operating loop around a coding agent: explicit context, visible controls, safe interruption, and reviewable output.</p>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener"><div class="source-title">pwrdrvr/openclaw-codex-app-server</div><div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div></a></div>
+
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -383,119 +210,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/codex-app-server-over-chat.html
+++ b/docs/blog/codex-app-server-over-chat.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 </div>
 </header>
 
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for Codex Workflows Moved Into Telegram and Discord" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>Codex Workflows Moved Into Telegram and Discord operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#F97316" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#F97316">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Coding agent surface</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-6452316466198740880" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#F97316"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">developer</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#F97316" stroke-width="3" marker-end="url(#arrow-6452316466198740880)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#F97316" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">Codex app server</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#F97316" stroke-width="3" marker-end="url(#arrow-6452316466198740880)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">reviewable change</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">repo context</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">task request</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">app server</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">diff/review</text>
+<rect x="58" y="312" width="704" height="2" fill="#F97316" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Coding agents become useful when they move from chat replies to inspectable workspace operations.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
+
 <div class="callout callout-info">
 <div class="callout-title">Timeline note</div>
 <p>This March post covers a third-party OpenClaw workflow source, not a core OpenClaw release. The source is <a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener">pwrdrvr/openclaw-codex-app-server</a>, a TypeScript plugin for connecting OpenClaw chat channels to the Codex App Server protocol.</p>
@@ -188,6 +214,9 @@ tr:last-child td{border-bottom:none}
 </div>
 <h2>The practical takeaway</h2>
 <p>The durable OpenClaw pattern here is “chat as request queue, local agent server as executor, repo as source of truth, PR as review boundary.” Telegram and Discord are not the product. The product is the operating loop around a coding agent: explicit context, visible controls, safe interruption, and reviewable output.</p>
+<h2>How I would read the diagram</h2>
+<p>The shift from chat to app server matters because code work needs state. A serious coding agent has to know the repo, run commands, inspect diffs, preserve context, and show what changed. A chat transcript alone is not enough operating surface.</p>
+<p>The practical standard is reviewability. If the agent proposes a change, the developer should be able to see the branch, the files touched, the tests run, and the assumptions made. Without that, the agent is not improving software delivery. It is just making confident text near a codebase.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener"><div class="source-title">pwrdrvr/openclaw-codex-app-server</div><div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div></a></div>
 

--- a/docs/blog/codex-app-server-over-chat.html
+++ b/docs/blog/codex-app-server-over-chat.html
@@ -20,44 +20,486 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Dev Tools</div>
 <h1 class="article-title">Codex Workflows Moved Into Telegram and Discord</h1>
 <p class="article-subtitle">OpenClaw Codex App Server shows the next developer workflow: coding agents controlled from chat, not just terminals.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Mar 13, 2026</span><span>8 min read</span><span>Week of Mar 10, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Codex</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Mar 13, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 10, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Codex</span>
 <span class="article-pill">Developer Tools</span>
-<span class="article-pill">ChatOps</span></div>
+<span class="article-pill">ChatOps</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Mar 13, 2026. Updated Apr 12, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>Codex Workflows Moved Into Telegram and Discord</strong></p>
-<p>The OpenClaw Codex App Server plugin brings Codex App Server workflows to Telegram and Discord. That is a concrete bridge between coding agents and the chat channels developers already monitor.</p>
-<h2>What actually changed</h2>
-<p>This is where agentic coding becomes operations. You do not just ask an IDE assistant to edit a file. You ask a chat-native agent to start work, report status, wait for approval, and hand back artifacts.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 10, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+The Codex App Server signal is that coding work is moving out of a single local prompt box and into chat-native workflows where humans can assign, observe, and review tasks asynchronously.
+</p>
+<p>
+The public source I am using here is pwrdrvr/openclaw-codex-app-server.
+OpenClaw plugin that brings Codex to Telegram and Discord via the Codex App Server protocol.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The mistake is to think the interface is the product.
+Telegram and Discord are not magic.
+The product is the workflow around them: who can ask, what can be changed, what evidence is returned, and how the change is reviewed.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>pwrdrvr/openclaw-codex-app-server</td></tr>
+<tr><td>Created</td><td>2026-03-13</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>243</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+A good chat-controlled coding agent should create a branch, explain its plan, run checks, link the diff, and stop before merging.
+That is the minimum shape of trust.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+If a chat agent cannot show the command it ran, the files it touched, and the tests it executed, it should not be allowed near a real repo.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The durable pattern is “chat as request queue, repo as source of truth, PR as review boundary.”
+</p>
 <h2>The practical read</h2>
-<p>Use chat-controlled coding agents for bounded tasks: tests, issue triage, docs updates, dependency checks. Keep repository write permissions explicit and require review before merge.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+Codex Workflows Moved Into Telegram and Discord is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener"><div class="source-title">pwrdrvr/openclaw-codex-app-server</div><div>https://github.com/pwrdrvr/openclaw-codex-app-server</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener">
+<div class="source-title">pwrdrvr/openclaw-codex-app-server</div>
+<div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/ten-agent-telegram-teams.html
+++ b/docs/blog/ten-agent-telegram-teams.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The 10-Agent Telegram Pattern Became Real</title>
-<meta name="description" content="openclaw-multi-agent-kit turns the multi-agent idea into a deployable team pattern with shared context and Telegram groups.">
+<meta name="description" content="A builder-focused analysis of OpenClaw multi-agent teams in Telegram: roles, topic routing, shared context, and operational boundaries.">
 <meta property="og:title" content="The 10-Agent Telegram Pattern Became Real">
-<meta property="og:description" content="openclaw-multi-agent-kit turns the multi-agent idea into a deployable team pattern with shared context and Telegram groups.">
+<meta property="og:description" content="A builder-focused analysis of OpenClaw multi-agent teams in Telegram: roles, topic routing, shared context, and operational boundaries.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/ten-agent-telegram-teams">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="The 10-Agent Telegram Pattern Became Real">
-<meta name="twitter:description" content="openclaw-multi-agent-kit turns the multi-agent idea into a deployable team pattern with shared context and Telegram groups.">
+<meta name="twitter:description" content="A builder-focused analysis of OpenClaw multi-agent teams in Telegram: roles, topic routing, shared context, and operational boundaries.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,240 +134,56 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Multi-Agent</div>
 <h1 class="article-title">The 10-Agent Telegram Pattern Became Real</h1>
-<p class="article-subtitle">openclaw-multi-agent-kit turns the multi-agent idea into a deployable team pattern with shared context and Telegram groups.</p>
+<p class="article-subtitle">The number of agents is not the point. The real lesson is how Telegram topics, shared files, and explicit roles turn multi-agent demos into an operating model.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Mar 31, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Builder/operator analysis</span>
 <span>Week of Mar 31, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">Telegram</span>
 <span class="article-pill">Multi-Agent</span>
-<span class="article-pill">Templates</span>
+<span class="article-pill">Teams</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 31, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+
+<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post looks at <a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener">raulvidis/openclaw-multi-agent-kit</a>, a March-era template kit for running OpenClaw agent teams through Telegram supergroups and topic channels.</p></div>
+<h2>The useful part is not “ten agents”</h2>
+<p>“Ten agents” is a catchy headline and a bad architecture principle. The useful part of <code>openclaw-multi-agent-kit</code> is that it treats multi-agent work as an operating system problem: identities, workspaces, topics, shared markdown context, escalation rules, cron schedules, and bot-to-bot triggers.</p>
+<p>The repository says it was built from a live production setup with ten autonomous agents. Each agent has a bot identity, personality, workspace, domain expertise, Telegram routing, and shared context workflow. Whether a team needs three agents or ten is secondary. What matters is that the kit forces builders to name the boundaries between roles.</p>
+<h2>What the kit actually contributes</h2>
+<div class="table-wrap"><table><thead><tr><th>Component</th><th>Builder value</th></tr></thead><tbody>
+<tr><td><code>SOUL.md</code> templates</td><td>Make agent behavior explicit instead of buried in ad hoc prompts.</td></tr>
+<tr><td><code>IDENTITY.md</code> templates</td><td>Document what an agent owns, what it can do, and when it should defer.</td></tr>
+<tr><td>Workspace templates</td><td>Give agents shared files for context, memory, and coordination.</td></tr>
+<tr><td><code>openclaw.json</code> snippets</td><td>Turn a concept into installable channel, binding, and agent configuration.</td></tr>
+<tr><td>Telegram topic routing docs</td><td>Show how conversations map to teams instead of one giant bot thread.</td></tr>
+<tr><td>Escalation chains</td><td>Prevent every agent from trying to answer every message.</td></tr>
+</tbody></table></div>
+<h2>The Telegram detail that matters</h2>
+<p>The most important caveat in the repo is also the most operationally honest: native topic routing changes the internal OpenClaw agent that handles a message; it does not necessarily change the visible Telegram bot identity. That distinction saves users from a lot of confusion.</p>
+<p>Telegram can provide a clean collaboration surface: one supergroup, forum topics for teams, visible handoffs, and human-readable context. But if visible identity, internal agent routing, and workspace ownership do not line up, the system becomes theatrical. People think they are talking to “Research” or “QA,” while the runtime may be using a different internal handler.</p>
+<h2>Good multi-agent design is mostly subtraction</h2>
+<p>The failure mode for multi-agent systems is not lack of agents. It is too many agents with overlapping authority. A useful team has a lead/orchestrator, clear specialist lanes, and boring rules for when to escalate. A noisy team has ten personalities all trying to be helpful.</p>
+<p>This kit is valuable because it gives builders something concrete to prune. Start from the templates, then remove roles until every remaining agent has a job that would still make sense if a human held it: research intake, code implementation, QA, deployment, content, community, or operations.</p>
+<div class="comparison"><div class="comparison-col before"><h4>Weak multi-agent setup</h4><ul><li>Agents differ only by persona.</li><li>Everyone can answer every thread.</li><li>Shared memory is implicit or stale.</li><li>No owner for final decisions.</li><li>No clear failure or escalation path.</li></ul></div><div class="comparison-col after"><h4>Stronger setup</h4><ul><li>Roles map to real work queues.</li><li>Topics route to primary owners.</li><li>Shared context is file-backed and reviewable.</li><li>Lead agent or human owns arbitration.</li><li>Escalation is written down.</li></ul></div></div>
+<h2>How I would run a pilot</h2>
+<p>I would not start with a ten-agent production deployment. I would start with three agents in one Telegram supergroup: Lead, Research, and Build. Give each one a workspace, a minimal <code>SOUL.md</code>, and a shared context file. Route one topic to each primary agent. Then test a real task: research an issue, propose a fix, implement a branch, and produce a human-readable summary.</p>
+<p>Only after that works would I add QA, Deploy, or Market roles. Every new agent should reduce cognitive load for the human operator. If a role adds notifications, debate, or duplicate output without making work easier to review, remove it.</p>
+<div class="checklist"><h3>Team deployment checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Define one owner per Telegram topic.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Write down when secondary agents may speak without being mentioned.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Keep shared context in files that humans can inspect and edit.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Separate visible Telegram identity from internal agent routing in the docs.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Measure whether the team reduces handoff time or just creates more chat.</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-The 10-agent Telegram pattern is a useful artifact because it makes multi-agent work visible in a group setting.
-People can see roles, handoffs, and outputs instead of trusting a hidden orchestration loop.
-</p>
-<p>
-The public source I am using here is raulvidis/openclaw-multi-agent-kit.
-Production-tested templates for deploying multi-agent AI teams on OpenClaw with Telegram supergroup integration.
-10 agent personalities, shared context workflows, bot-to-bot communication, and step-by-step AI-readable setup instructions.
-Built from a live 10-agent setup.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that ten agents is the magic number.
-The number is not the point.
-The point is whether each role has a reason to exist.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>raulvidis/openclaw-multi-agent-kit</td></tr>
-<tr><td>Created</td><td>2026-03-04</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>354</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-Telegram groups are useful for coordination because the conversation is visible.
-The challenge is preventing every agent from replying to every event.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-The system needs routing rules, shared context, and a moderator role.
-Otherwise it becomes a noisy demo.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-Expect multi-agent teams to start in chat because chat makes collaboration inspectable.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-The 10-Agent Telegram Pattern Became Real is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener">
-<div class="source-title">raulvidis/openclaw-multi-agent-kit</div>
-<div class="source-url">https://github.com/raulvidis/openclaw-multi-agent-kit</div>
-</a>
-</div>
+<h2>The practical takeaway</h2>
+<p>The March signal is that OpenClaw users are moving from “one assistant in one chat” toward “agent teams with operating rules.” The right benchmark is not how many agents are running. It is whether a human can see who owns the task, what context was used, what changed, and where to intervene.</p>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener"><div class="source-title">raulvidis/openclaw-multi-agent-kit</div><div class="source-url">https://github.com/raulvidis/openclaw-multi-agent-kit</div></a></div>
+<div class="source-ref"><a href="https://blog.cdnsun.com/multi-agents-in-openclaw-sub-agents-and-telegram/" target="_blank" rel="noopener"><div class="source-title">Multi-agents in OpenClaw: sub-agents and Telegram</div><div class="source-url">https://blog.cdnsun.com/multi-agents-in-openclaw-sub-agents-and-telegram/</div></a></div>
+
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -387,119 +203,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/ten-agent-telegram-teams.html
+++ b/docs/blog/ten-agent-telegram-teams.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 </div>
 </header>
 
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for The 10-Agent Telegram Pattern Became Real" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>The 10-Agent Telegram Pattern Became Real operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#06B6D4" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#06B6D4">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Agent team over chat</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-201913193557605011" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#06B6D4"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">group request</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#06B6D4" stroke-width="3" marker-end="url(#arrow-201913193557605011)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#06B6D4" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">agent team</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#06B6D4" stroke-width="3" marker-end="url(#arrow-201913193557605011)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">human-readable result</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">Telegram topic</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">agent role</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">handoff</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">summary</text>
+<rect x="58" y="312" width="704" height="2" fill="#06B6D4" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Many agents in a chat room need roles, handoffs, and summaries, otherwise they become noise.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
+
 <div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post looks at <a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener">raulvidis/openclaw-multi-agent-kit</a>, a March-era template kit for running OpenClaw agent teams through Telegram supergroups and topic channels.</p></div>
 <h2>The useful part is not “ten agents”</h2>
 <p>“Ten agents” is a catchy headline and a bad architecture principle. The useful part of <code>openclaw-multi-agent-kit</code> is that it treats multi-agent work as an operating system problem: identities, workspaces, topics, shared markdown context, escalation rules, cron schedules, and bot-to-bot triggers.</p>
@@ -180,6 +206,12 @@ tr:last-child td{border-bottom:none}
 </div>
 <h2>The practical takeaway</h2>
 <p>The March signal is that OpenClaw users are moving from “one assistant in one chat” toward “agent teams with operating rules.” The right benchmark is not how many agents are running. It is whether a human can see who owns the task, what context was used, what changed, and where to intervene.</p>
+<h2>How I would read the diagram</h2>
+<p>A Telegram group full of agents sounds fun until the first real incident. Then the questions become practical: who owns the task, who is allowed to call tools, where does the summary live, and how does a human stop the loop?</p>
+<p>The useful pattern is not “ten agents everywhere.” It is a small set of specialized roles with a visible coordinator. Chat is good for coordination because humans already understand it. But the agent layer has to respect the room: concise updates, clear handoffs, and no hidden long-running work without status.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener"><div class="source-title">raulvidis/openclaw-multi-agent-kit</div><div class="source-url">https://github.com/raulvidis/openclaw-multi-agent-kit</div></a></div>
 <div class="source-ref"><a href="https://blog.cdnsun.com/multi-agents-in-openclaw-sub-agents-and-telegram/" target="_blank" rel="noopener"><div class="source-title">Multi-agents in OpenClaw: sub-agents and Telegram</div><div class="source-url">https://blog.cdnsun.com/multi-agents-in-openclaw-sub-agents-and-telegram/</div></a></div>

--- a/docs/blog/ten-agent-telegram-teams.html
+++ b/docs/blog/ten-agent-telegram-teams.html
@@ -20,44 +20,490 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Multi-Agent</div>
 <h1 class="article-title">The 10-Agent Telegram Pattern Became Real</h1>
 <p class="article-subtitle">openclaw-multi-agent-kit turns the multi-agent idea into a deployable team pattern with shared context and Telegram groups.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Mar 31, 2026</span><span>8 min read</span><span>Week of Mar 31, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Telegram</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Mar 31, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 31, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Telegram</span>
 <span class="article-pill">Multi-Agent</span>
-<span class="article-pill">Templates</span></div>
+<span class="article-pill">Templates</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Mar 4, 2026. Updated Mar 31, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>The 10-Agent Telegram Pattern Became Real</strong></p>
-<p>openclaw-multi-agent-kit packages a live 10-agent setup with Telegram supergroup integration, shared context workflows, bot-to-bot communication, and AI-readable setup instructions.</p>
-<h2>What actually changed</h2>
-<p>This is the difference between a concept and a pattern. Multi-agent systems become understandable when each agent has a channel, role, memory boundary, and handoff rule.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 31, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+The 10-agent Telegram pattern is a useful artifact because it makes multi-agent work visible in a group setting.
+People can see roles, handoffs, and outputs instead of trusting a hidden orchestration loop.
+</p>
+<p>
+The public source I am using here is raulvidis/openclaw-multi-agent-kit.
+Production-tested templates for deploying multi-agent AI teams on OpenClaw with Telegram supergroup integration.
+10 agent personalities, shared context workflows, bot-to-bot communication, and step-by-step AI-readable setup instructions.
+Built from a live 10-agent setup.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that ten agents is the magic number.
+The number is not the point.
+The point is whether each role has a reason to exist.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>raulvidis/openclaw-multi-agent-kit</td></tr>
+<tr><td>Created</td><td>2026-03-04</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>354</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+Telegram groups are useful for coordination because the conversation is visible.
+The challenge is preventing every agent from replying to every event.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+The system needs routing rules, shared context, and a moderator role.
+Otherwise it becomes a noisy demo.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+Expect multi-agent teams to start in chat because chat makes collaboration inspectable.
+</p>
 <h2>The practical read</h2>
-<p>Start with three roles before ten: operator, researcher, reviewer. Add more only when the handoff is obvious and the logs show real load.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+The 10-Agent Telegram Pattern Became Real is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener"><div class="source-title">raulvidis/openclaw-multi-agent-kit</div><div>https://github.com/raulvidis/openclaw-multi-agent-kit</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/raulvidis/openclaw-multi-agent-kit" target="_blank" rel="noopener">
+<div class="source-title">raulvidis/openclaw-multi-agent-kit</div>
+<div class="source-url">https://github.com/raulvidis/openclaw-multi-agent-kit</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/v2026-3-24-plugin-compatibility.html
+++ b/docs/blog/v2026-3-24-plugin-compatibility.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call</title>
-<meta name="description" content="The late-March release window showed why OpenClaw guides need version notes: external channel plugins can break when the runtime changes.">
+<meta name="description" content="A release-window analysis of OpenClaw v2026.3.24: API compatibility, channel SDK changes, plugin hooks, tool visibility, and upgrade discipline.">
 <meta property="og:title" content="OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call">
-<meta property="og:description" content="The late-March release window showed why OpenClaw guides need version notes: external channel plugins can break when the runtime changes.">
+<meta property="og:description" content="A release-window analysis of OpenClaw v2026.3.24: API compatibility, channel SDK changes, plugin hooks, tool visibility, and upgrade discipline.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/v2026-3-24-plugin-compatibility">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call">
-<meta name="twitter:description" content="The late-March release window showed why OpenClaw guides need version notes: external channel plugins can break when the runtime changes.">
+<meta name="twitter:description" content="A release-window analysis of OpenClaw v2026.3.24: API compatibility, channel SDK changes, plugin hooks, tool visibility, and upgrade discipline.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,11 +134,11 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Release</div>
 <h1 class="article-title">OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call</h1>
-<p class="article-subtitle">The late-March release window showed why OpenClaw guides need version notes: external channel plugins can break when the runtime changes.</p>
+<p class="article-subtitle">The late-March release was not just a feature drop. It showed why OpenClaw plugins now need version matrices, smoke tests, and rollback plans.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Mar 25, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Builder/operator analysis</span>
 <span>Week of Mar 24, 2026</span>
 </div>
 <div class="article-pills">
@@ -147,227 +147,45 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Compatibility</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 24, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+
+<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post focuses on the <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener">OpenClaw v2026.3.24</a> release window and what it means for plugin builders. It is not a generic release recap; it is a compatibility read.</p></div>
+<h2>The release was a contract test for the ecosystem</h2>
+<p>OpenClaw v2026.3.24 shipped the kind of changes that make an ecosystem feel real: OpenAI-compatible gateway endpoints, clearer tools visibility, Microsoft Teams SDK migration, skills install metadata, Slack interactive reply fixes, container-aware CLI commands, Discord auto-thread naming, and plugin hook work such as <code>before_dispatch</code>.</p>
+<p>None of that is filler. Each item touches a contract external builders depend on: HTTP API shape, channel behavior, tool visibility, plugin hooks, skills metadata, runtime requirements, and deployment assumptions. This is why late March should be read as a compatibility moment, not only a feature release.</p>
+<div class="table-wrap"><table><thead><tr><th>Release area</th><th>Why plugin builders should care</th></tr></thead><tbody>
+<tr><td>OpenAI-compatible endpoints</td><td><code>/v1/models</code>, <code>/v1/embeddings</code>, and model override forwarding make more clients possible, but they also set API expectations.</td></tr>
+<tr><td>Tools visibility</td><td><code>/tools</code> and Control UI now emphasize tools available to the current agent, reducing false promises in prompts.</td></tr>
+<tr><td>Teams SDK migration</td><td>Channel integrations can change substantially when a platform SDK becomes official or gets replaced.</td></tr>
+<tr><td>Skills metadata</td><td>One-click install recipes move skills closer to packaged dependencies, which requires accurate requirements.</td></tr>
+<tr><td>Plugin hooks</td><td><code>before_dispatch</code> and canonical inbound metadata give plugins more power and a sharper need for stable contracts.</td></tr>
+<tr><td>Node floor</td><td>Supporting Node <code>22.14+</code> while recommending Node 24 affects install paths and support matrices.</td></tr>
+</tbody></table></div>
+<h2>Why “no breaking changes” does not mean “nothing can break”</h2>
+<p>The GitHub release summary did not list formal breaking changes. But ecosystem compatibility is broader than a Breaking section. A plugin can break because an export path moved, an adapter split, a channel facade changed, an update command cannot pass a needed flag, or a tool visibility rule hides something the plugin assumed was available.</p>
+<p>The Codex App Server bridge demonstrates this in practice. Its README later needed a compatibility matrix across OpenClaw <code>2026.3.22</code>, <code>2026.3.31</code>, <code>v2026.4.2</code>, and newer local checkouts. That is what a fast runtime looks like from the outside: release notes tell one story; plugin READMEs tell the operational story.</p>
+<h2>The compatibility matrix should become normal</h2>
+<p>OpenClaw is moving from a single repo to a plugin ecosystem. Once that happens, every serious integration should publish three things:</p>
+<ul>
+<li><strong>Minimum OpenClaw version:</strong> the earliest tested runtime.</li>
+<li><strong>Maximum known-good version or range:</strong> especially for channel SDKs and plugin facades.</li>
+<li><strong>Failure notes:</strong> what breaks when the runtime is too old, too new, or missing unsafe-install/update behavior.</li>
+</ul>
+<p>This is not bureaucracy. It is how maintainers avoid turning every support thread into archaeology.</p>
+<div class="comparison"><div class="comparison-col before"><h4>Weak release practice</h4><ul><li>“Install latest” as the only instruction.</li><li>No runtime range.</li><li>No channel-specific notes.</li><li>No rollback command.</li><li>No test fixture for plugin hooks.</li></ul></div><div class="comparison-col after"><h4>Better release practice</h4><ul><li>Pin and test against named OpenClaw versions.</li><li>Document install, update, and uninstall paths.</li><li>List channel SDK assumptions.</li><li>Provide a known-good matrix.</li><li>Run smoke tests for every supported channel.</li></ul></div></div>
+<h2>What operators should do before upgrading</h2>
+<div class="checklist"><h3>Upgrade checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Inventory installed plugins, channel integrations, skills, and custom hooks.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Read release notes for API endpoints, channel SDK changes, tool visibility, and runtime requirements.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Run a staging gateway with representative Telegram, Discord, Slack, Teams, and web tool flows.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Verify plugin install/update commands, including unsafe-install flags when a plugin launches subprocesses.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Keep a rollback path and the previous working OpenClaw/plugin versions.</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-The v2026.3.24 release window is a compatibility story.
-Fast-moving runtimes are exciting, but every external plugin now depends on stable contracts.
-</p>
-<p>
-The public source I am using here is openclaw/openclaw.
-Your own personal AI assistant.
-Any OS.
-Any Platform.
-The lobster way.
-🦞
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that a breaking plugin is just a plugin bug.
-Sometimes it is.
-But often it means the ecosystem does not have enough contract tests.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>openclaw/openclaw</td></tr>
-<tr><td>Created</td><td>2025-11-24</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>365603</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-Builders need version notes, minimum runtime versions, and compatibility checks before telling users to install anything.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-Operators need upgrade windows, rollback instructions, and a way to know which plugins are safe after a release.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-OpenClaw needs an ecosystem compatibility matrix as the plugin surface grows.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener">
-<div class="source-title">openclaw/openclaw</div>
-<div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.3.24</div>
-</a>
-</div>
+<h2>The practical takeaway</h2>
+<p>v2026.3.24 was not only a feature drop. It was a reminder that OpenClaw is now an integration surface. The more useful the runtime becomes, the more important compatibility discipline becomes: signed releases, precise version notes, plugin matrices, smoke tests, and honest documentation about what changed.</p>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener"><div class="source-title">openclaw/openclaw v2026.3.24 release</div><div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.3.24</div></a></div>
+<div class="source-ref"><a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener"><div class="source-title">pwrdrvr/openclaw-codex-app-server compatibility notes</div><div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div></a></div>
+
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -387,119 +205,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/v2026-3-24-plugin-compatibility.html
+++ b/docs/blog/v2026-3-24-plugin-compatibility.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 </div>
 </header>
 
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#8B5CF6" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#8B5CF6">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Compatibility layer</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-3806648172243944320" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#8B5CF6"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">old plugin</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#8B5CF6" stroke-width="3" marker-end="url(#arrow-3806648172243944320)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#8B5CF6" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">compatibility gate</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#8B5CF6" stroke-width="3" marker-end="url(#arrow-3806648172243944320)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">stable host</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">host version</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">plugin API</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">channel package</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">migration</text>
+<rect x="58" y="312" width="704" height="2" fill="#8B5CF6" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Plugin ecosystems grow only when compatibility is explicit and migrations are boring.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
+
 <div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post focuses on the <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener">OpenClaw v2026.3.24</a> release window and what it means for plugin builders. It is not a generic release recap; it is a compatibility read.</p></div>
 <h2>The release was a contract test for the ecosystem</h2>
 <p>OpenClaw v2026.3.24 shipped the kind of changes that make an ecosystem feel real: OpenAI-compatible gateway endpoints, clearer tools visibility, Microsoft Teams SDK migration, skills install metadata, Slack interactive reply fixes, container-aware CLI commands, Discord auto-thread naming, and plugin hook work such as <code>before_dispatch</code>.</p>
@@ -182,6 +208,14 @@ tr:last-child td{border-bottom:none}
 </div>
 <h2>The practical takeaway</h2>
 <p>v2026.3.24 was not only a feature drop. It was a reminder that OpenClaw is now an integration surface. The more useful the runtime becomes, the more important compatibility discipline becomes: signed releases, precise version notes, plugin matrices, smoke tests, and honest documentation about what changed.</p>
+<h2>How I would read the diagram</h2>
+<p>Compatibility is not glamorous, but it decides whether an ecosystem survives. If every channel plugin breaks on every host release, developers stop building around the platform. If the compatibility story is visible, versioned, and boring, contributors can take reasonable risk.</p>
+<p>The March signal matters because OpenClaw is no longer just one repo. It is a host plus channels plus plugins plus deployment surfaces. That means release notes and compatibility ranges become part of the developer experience, not administrative noise.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener"><div class="source-title">openclaw/openclaw v2026.3.24 release</div><div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.3.24</div></a></div>
 <div class="source-ref"><a href="https://github.com/pwrdrvr/openclaw-codex-app-server" target="_blank" rel="noopener"><div class="source-title">pwrdrvr/openclaw-codex-app-server compatibility notes</div><div class="source-url">https://github.com/pwrdrvr/openclaw-codex-app-server</div></a></div>

--- a/docs/blog/v2026-3-24-plugin-compatibility.html
+++ b/docs/blog/v2026-3-24-plugin-compatibility.html
@@ -20,40 +20,490 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Release</div>
 <h1 class="article-title">OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call</h1>
 <p class="article-subtitle">The late-March release window showed why OpenClaw guides need version notes: external channel plugins can break when the runtime changes.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Mar 25, 2026</span><span>8 min read</span><span>Week of Mar 24, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Release</span><span class="article-pill">Plugins</span><span class="article-pill">Compatibility</span></div>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Mar 25, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 24, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Release</span>
+<span class="article-pill">Plugins</span>
+<span class="article-pill">Compatibility</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>v2026.3.22 and v2026.3.23 landed Mar 23, 2026. v2026.3.24 was published Mar 25, 2026, with issue reports around external plugin compatibility in the same window.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>OpenClaw v2026.3.24 was the week where plugin compatibility stopped being a background concern.</strong></p>
-<p>The late-March release window had daily OpenClaw tags, external channel plugin reports, and SDK-path churn showing up in public issues. That is a useful ecosystem marker. The project was not only adding plugins anymore. It was discovering how fragile plugin contracts become when the runtime moves fast.</p>
-<h2>What actually changed</h2>
-<p>A fast-moving agent runtime is good until every guide assumes yesterday's plugin API still works. Channel plugins, observability plugins, and memory plugins all depend on runtime contracts. When those contracts move, users need version context.</p>
-<p>This is why timeline discipline matters. A March compatibility post should not be mixed with February launch hype or April release-cadence notes. They are different stages of the same ecosystem.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>Plugin compatibility is part of that control. If a channel breaks after an upgrade, the user does not care that the ecosystem is growing. They care that the assistant disappeared from the surface where work happens.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 24, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+The v2026.3.24 release window is a compatibility story.
+Fast-moving runtimes are exciting, but every external plugin now depends on stable contracts.
+</p>
+<p>
+The public source I am using here is openclaw/openclaw.
+Your own personal AI assistant.
+Any OS.
+Any Platform.
+The lobster way.
+🦞
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that a breaking plugin is just a plugin bug.
+Sometimes it is.
+But often it means the ecosystem does not have enough contract tests.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>openclaw/openclaw</td></tr>
+<tr><td>Created</td><td>2025-11-24</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>365603</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+Builders need version notes, minimum runtime versions, and compatibility checks before telling users to install anything.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+Operators need upgrade windows, rollback instructions, and a way to know which plugins are safe after a release.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+OpenClaw needs an ecosystem compatibility matrix as the plugin surface grows.
+</p>
 <h2>The practical read</h2>
-<p>Write plugin docs with tested OpenClaw versions, install date, package version, and fallback steps. If a plugin depends on a moving SDK path, say so clearly instead of pretending every latest version works.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add release-sensitive projects with date context. For plugin entries, include what surface they connect, when the source was verified, and which runtime window the write-up is based on.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+OpenClaw v2026.3.24 Was a Plugin Compatibility Wake-Up Call is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener"><div class="source-title">OpenClaw v2026.3.24</div><div>https://github.com/openclaw/openclaw/releases/tag/v2026.3.24</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/openclaw/openclaw/releases/tag/v2026.3.24" target="_blank" rel="noopener">
+<div class="source-title">openclaw/openclaw</div>
+<div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.3.24</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/web-data-plugins-need-safety.html
+++ b/docs/blog/web-data-plugins-need-safety.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Web Data Plugins Are Useful, But They Need Guardrails</title>
-<meta name="description" content="Bright Data&#x27;s OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta name="description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
 <meta property="og:title" content="Web Data Plugins Are Useful, But They Need Guardrails">
-<meta property="og:description" content="Bright Data&#x27;s OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta property="og:description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/web-data-plugins-need-safety">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Web Data Plugins Are Useful, But They Need Guardrails">
-<meta name="twitter:description" content="Bright Data&#x27;s OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta name="twitter:description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -20,44 +20,486 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Web Data</div>
 <h1 class="article-title">Web Data Plugins Are Useful, But They Need Guardrails</h1>
-<p class="article-subtitle">Bright Data&#x27;s OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Mar 25, 2026</span><span>8 min read</span><span>Week of Mar 24, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Web Data</span>
+<p class="article-subtitle">Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.</p>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Mar 25, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 24, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Web Data</span>
 <span class="article-pill">Browser</span>
-<span class="article-pill">Safety</span></div>
+<span class="article-pill">Safety</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Mar 25, 2026. Updated Apr 19, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>Web Data Plugins Are Useful, But They Need Guardrails</strong></p>
-<p>The Bright Data OpenClaw plugin connects web search, structured data tools, and browser automation-style workflows to agents. That is useful for research and monitoring, but it also raises the bar for policy and compliance.</p>
-<h2>What actually changed</h2>
-<p>Agents with web data tools can gather context faster than humans. They can also cross boundaries faster than humans. The tool is not the problem. Unclear policy is the problem.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 24, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+Web data plugins are powerful.
+That is exactly why they need guardrails.
+Bright Data entering the OpenClaw surface is a reminder that agents can reach into external data systems, not just local tools.
+</p>
+<p>
+The public source I am using here is brightdata/openclaw-plugin.
+Free OpenClaw plugin for Bright Data - web search, web scraping with bot bypass, browser automation, and 50+ structured data tools for Amazon, LinkedIn, Instagram, TikTok, YouTube, Reddit and more.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that more data access automatically makes agents better.
+Without policy, logging, and limits, it only makes failures more expensive.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>brightdata/openclaw-plugin</td></tr>
+<tr><td>Created</td><td>2026-03-25</td></tr>
+<tr><td>Last public update</td><td>2026-04-21</td></tr>
+<tr><td>Stars at review time</td><td>6</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+A safe web data integration needs scoped use cases, input validation, rate limits, provenance, and clear output summaries.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+Operators should ask what sites are accessed, what data is stored, what credentials are used, and how abuse is prevented.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+Agent data access will need the same discipline as API access: keys, scopes, logs, and review.
+</p>
 <h2>The practical read</h2>
-<p>Document allowed sources, rate limits, account boundaries, and data retention. Make the agent cite sources. Keep sensitive platforms and logged-in sessions behind explicit user approval.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+Web Data Plugins Are Useful, But They Need Guardrails is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener"><div class="source-title">brightdata/openclaw-plugin</div><div>https://github.com/brightdata/openclaw-plugin</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener">
+<div class="source-title">brightdata/openclaw-plugin</div>
+<div class="source-url">https://github.com/brightdata/openclaw-plugin</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/web-data-plugins-need-safety.html
+++ b/docs/blog/web-data-plugins-need-safety.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Web Data Plugins Are Useful, But They Need Guardrails</title>
-<meta name="description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta name="description" content="Bright Data’s OpenClaw plugin expands agents into search, scraping, browser automation, and structured web data. That power needs policy, logging, and scope.">
 <meta property="og:title" content="Web Data Plugins Are Useful, But They Need Guardrails">
-<meta property="og:description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta property="og:description" content="Bright Data’s OpenClaw plugin expands agents into search, scraping, browser automation, and structured web data. That power needs policy, logging, and scope.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/web-data-plugins-need-safety">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Web Data Plugins Are Useful, But They Need Guardrails">
-<meta name="twitter:description" content="Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.">
+<meta name="twitter:description" content="Bright Data’s OpenClaw plugin expands agents into search, scraping, browser automation, and structured web data. That power needs policy, logging, and scope.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,11 +134,11 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Web Data</div>
 <h1 class="article-title">Web Data Plugins Are Useful, But They Need Guardrails</h1>
-<p class="article-subtitle">Bright Data's OpenClaw plugin is a reminder that powerful web data access needs policy, logging, and restraint.</p>
+<p class="article-subtitle">Bright Data’s plugin shows how useful web access can be for OpenClaw agents, and why operators need tool scoping, provenance, and policy before enabling it.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Mar 25, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Builder/operator analysis</span>
 <span>Week of Mar 24, 2026</span>
 </div>
 <div class="article-pills">
@@ -147,223 +147,41 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Safety</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 24, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+
+<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post covers the Bright Data OpenClaw plugin and docs published around the late-March ecosystem window: <a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener">brightdata/openclaw-plugin</a> and Bright Data's OpenClaw integration guide.</p></div>
+<h2>Web access is where agent risk stops being theoretical</h2>
+<p>A local automation agent that reads files is already powerful. A web data plugin that adds search, scraping, browser automation, residential proxy infrastructure, and structured data tools changes the blast radius. The Bright Data plugin is useful precisely because it makes that shift visible.</p>
+<p>The repository advertises real-time web search, bot-bypass scraping, browser automation, and structured tools for platforms such as Amazon, LinkedIn, Instagram, TikTok, YouTube, and Reddit. The docs describe 66 tools across search, scrape, batch operations, browser automation, and structured web data. That is not a small helper. That is a major expansion of what an OpenClaw agent can touch.</p>
+<h2>What the plugin gives builders</h2>
+<div class="table-wrap"><table><thead><tr><th>Capability</th><th>Practical use</th><th>Risk to manage</th></tr></thead><tbody>
+<tr><td>Search</td><td>Fresh SERP results from Google, Bing, or Yandex with geo-targeting.</td><td>Prompt injection from search snippets and untrusted pages.</td></tr>
+<tr><td>Scrape</td><td>Fetch pages through Web Unlocker, including JavaScript-rendered or bot-protected sites.</td><td>Terms-of-service, rate, privacy, and data-retention issues.</td></tr>
+<tr><td>Batch tools</td><td>Run several searches or scrapes in parallel.</td><td>Cost spikes and noisy failures if an agent loops.</td></tr>
+<tr><td>Browser automation</td><td>Drive a real Chromium browser through proxy infrastructure.</td><td>Actions that look like account management or abuse if not constrained.</td></tr>
+<tr><td>Structured data tools</td><td>Pull platform-specific data without hand-parsing HTML.</td><td>Overcollection and unclear provenance in downstream summaries.</td></tr>
+</tbody></table></div>
+<h2>The policy note is not boilerplate</h2>
+<p>Bright Data's own OpenClaw docs include an important notice: account management is not a supported use case as of April 1, 2026, including platforms like TikTok and Instagram, and Bright Data proxies cannot be used for that purpose. That should shape how builders expose these tools to agents.</p>
+<p>If a tool can browse, scrape, and interact through proxy infrastructure, the agent needs a policy layer before the tool call, not after the incident. “Use the browser to gather market data” and “log into fifty accounts and perform actions” can look similar to a language model unless the operator defines boundaries in configuration and prompt policy.</p>
+<div class="callout callout-tip"><div class="callout-title">Builder rule</div><p>Do not give a general-purpose agent 66 web tools and hope the prompt keeps it polite. Expose the smallest tool group needed for the job, log every external URL, and require human approval for browser actions that submit forms, authenticate, purchase, message, or mutate state.</p></div>
+<h2>How I would wire this safely</h2>
+<p>For a research assistant, I would allow <code>brightdata_search</code> and a tightly bounded scrape tool with a small <code>maxChars</code> default. For a competitive intelligence workflow, I would add structured data tools one platform at a time and require source URLs in every summary. For browser automation, I would create a separate agent with a narrow instruction set and no account credentials.</p>
+<p>I would also separate data retrieval from decision-making. The web-data agent fetches and cites. A different agent or human evaluates. That separation makes prompt injection less catastrophic because the page being scraped is not also controlling the final action.</p>
+<h2>Operational checks before enabling it</h2>
+<div class="checklist"><h3>Guardrail checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Store <code>BRIGHTDATA_API_TOKEN</code> outside prompts and logs.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Decide whether automatic zone creation is acceptable or pre-create approved zones.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Allow only the tool categories the agent actually needs.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Log query, URL, tool name, output size, and requesting agent for every call.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Block account management, credentialed browsing, form submission, and state-changing actions unless separately approved.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Require citations and provenance in summaries produced from scraped data.</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-Web data plugins are powerful.
-That is exactly why they need guardrails.
-Bright Data entering the OpenClaw surface is a reminder that agents can reach into external data systems, not just local tools.
-</p>
-<p>
-The public source I am using here is brightdata/openclaw-plugin.
-Free OpenClaw plugin for Bright Data - web search, web scraping with bot bypass, browser automation, and 50+ structured data tools for Amazon, LinkedIn, Instagram, TikTok, YouTube, Reddit and more.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that more data access automatically makes agents better.
-Without policy, logging, and limits, it only makes failures more expensive.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>brightdata/openclaw-plugin</td></tr>
-<tr><td>Created</td><td>2026-03-25</td></tr>
-<tr><td>Last public update</td><td>2026-04-21</td></tr>
-<tr><td>Stars at review time</td><td>6</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-A safe web data integration needs scoped use cases, input validation, rate limits, provenance, and clear output summaries.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-Operators should ask what sites are accessed, what data is stored, what credentials are used, and how abuse is prevented.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-Agent data access will need the same discipline as API access: keys, scopes, logs, and review.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-Web Data Plugins Are Useful, But They Need Guardrails is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener">
-<div class="source-title">brightdata/openclaw-plugin</div>
-<div class="source-url">https://github.com/brightdata/openclaw-plugin</div>
-</a>
-</div>
+<h2>The practical takeaway</h2>
+<p>Bright Data's plugin is a serious capability, not just another directory item. It makes OpenClaw more useful for fresh research and structured web workflows, but it also forces operators to treat web access like production infrastructure: scoped credentials, explicit policy, rate controls, logs, and source provenance.</p>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener"><div class="source-title">brightdata/openclaw-plugin</div><div class="source-url">https://github.com/brightdata/openclaw-plugin</div></a></div>
+<div class="source-ref"><a href="https://docs.brightdata.com/integrations/openclaw" target="_blank" rel="noopener"><div class="source-title">Set Up Bright Data With OpenClaw</div><div class="source-url">https://docs.brightdata.com/integrations/openclaw</div></a></div>
+
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -383,119 +201,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/web-data-plugins-need-safety.html
+++ b/docs/blog/web-data-plugins-need-safety.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 </div>
 </header>
 
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for Web Data Plugins Are Useful, But They Need Guardrails" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>Web Data Plugins Are Useful, But They Need Guardrails operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#EF4444" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#EF4444">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Web data boundary</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-573472740876557379" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#EF4444"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">web source</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#EF4444" stroke-width="3" marker-end="url(#arrow-573472740876557379)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#EF4444" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">data plugin</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#EF4444" stroke-width="3" marker-end="url(#arrow-573472740876557379)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">bounded context</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">source</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">policy</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">fetch</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">retain/discard</text>
+<rect x="58" y="312" width="704" height="2" fill="#EF4444" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">The useful web-data plugin is the one that can say what it fetched, why it fetched it, and what it did not keep.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
+
 <div class="callout callout-info"><div class="callout-title">Timeline note</div><p>This post covers the Bright Data OpenClaw plugin and docs published around the late-March ecosystem window: <a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener">brightdata/openclaw-plugin</a> and Bright Data's OpenClaw integration guide.</p></div>
 <h2>Web access is where agent risk stops being theoretical</h2>
 <p>A local automation agent that reads files is already powerful. A web data plugin that adds search, scraping, browser automation, residential proxy infrastructure, and structured data tools changes the blast radius. The Bright Data plugin is useful precisely because it makes that shift visible.</p>
@@ -178,6 +204,14 @@ tr:last-child td{border-bottom:none}
 </div>
 <h2>The practical takeaway</h2>
 <p>Bright Data's plugin is a serious capability, not just another directory item. It makes OpenClaw more useful for fresh research and structured web workflows, but it also forces operators to treat web access like production infrastructure: scoped credentials, explicit policy, rate controls, logs, and source provenance.</p>
+<h2>How I would read the diagram</h2>
+<p>Web data is where agent systems can become sloppy very quickly. A plugin that fetches a page, a search result, or a structured dataset should not be treated as neutral plumbing. It decides what enters context, what gets summarized, and what might be stored.</p>
+<p>That is why the safety work is part of the product, not a legal appendix. The plugin should have rate limits, source visibility, retention rules, and failure messages that a user can understand. If those pieces are missing, the agent may look smarter while becoming harder to trust.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/brightdata/openclaw-plugin" target="_blank" rel="noopener"><div class="source-title">brightdata/openclaw-plugin</div><div class="source-url">https://github.com/brightdata/openclaw-plugin</div></a></div>
 <div class="source-ref"><a href="https://docs.brightdata.com/integrations/openclaw" target="_blank" rel="noopener"><div class="source-title">Set Up Bright Data With OpenClaw</div><div class="source-url">https://docs.brightdata.com/integrations/openclaw</div></a></div>


### PR DESCRIPTION
## Summary
- Rewrites this batch of previously short timeline posts into detailed long-form OpenClaw ecosystem analysis
- Uses Rohit writing style: practical builder/operator lens, timeline note, source evidence, operational risks, and concrete takeaways
- Keeps claims bounded to public source metadata and avoids hype/internal-tool language

## Posts
- docs/blog/codex-app-server-over-chat.html
- docs/blog/ten-agent-telegram-teams.html
- docs/blog/web-data-plugins-need-safety.html
- docs/blog/v2026-3-24-plugin-compatibility.html

## Test Plan
- python3 scripts/validate_static.py
- git diff --check
- line-count check: all changed posts are 500+ lines
