### PR TITLE
docs: expand April OpenClaw infrastructure blog posts

### DIFF
--- a/docs/blog/dashboard-layer-arrives.html
+++ b/docs/blog/dashboard-layer-arrives.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Security</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for The Dashboard Layer Arrived Because Agents Need Supervision" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>The Dashboard Layer Arrived Because Agents Need Supervision operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#3B82F6" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#3B82F6">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Control plane view</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-7386473003568877020" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#3B82F6"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">operator</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow-7386473003568877020)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#3B82F6" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">dashboard</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow-7386473003568877020)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">controlled system</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">runs</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">tools</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">logs</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">settings</text>
+<rect x="58" y="312" width="704" height="2" fill="#3B82F6" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">A dashboard is valuable when it turns invisible agent behavior into something operators can inspect and change.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
 <h2>The useful read</h2>
 <p>A dashboard for OpenClaw is not valuable because it makes agents look polished. It is valuable if it turns an agent from a mysterious background process into an inspectable service. Once an agent can read files, call tools, remember context, spend tokens, and run for more than one request, operators need a control surface.</p>
@@ -181,6 +207,14 @@ tr:last-child td{border-bottom:none}
 <div class="checklist-item"><span class="checklist-box"></span><span>Are costs broken down by model, user, skill, and run?</span></div>
 <div class="checklist-item"><span class="checklist-box"></span><span>Is authentication more than a shared admin password?</span></div>
 </div>
+<h2>How I would read the diagram</h2>
+<p>The dashboard layer matters because agent systems create state in places users cannot easily see: tool permissions, sessions, memory, model settings, traces, and background jobs. A CLI can operate the system, but a dashboard helps people understand it.</p>
+<p>The trap is making the dashboard a vanity panel. Counts and pretty cards are not enough. The useful dashboard answers operational questions: what is running, what failed, what tool was called, which model answered, what changed, and where a user can safely intervene.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/tugcantopaloglu/openclaw-dashboard" target="_blank" rel="noopener">

--- a/docs/blog/dashboard-layer-arrives.html
+++ b/docs/blog/dashboard-layer-arrives.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Dashboard Layer Arrived Because Agents Need Supervision</title>
-<meta name="description" content="openclaw-dashboard points to a boring but necessary truth: long-running agents need a control room.">
+<meta name="description" content="openclaw-dashboard is less interesting as a UI and more interesting as an operations pattern: long-running agents need identity, traces, budgets, logs, and a human stop button.">
 <meta property="og:title" content="The Dashboard Layer Arrived Because Agents Need Supervision">
-<meta property="og:description" content="openclaw-dashboard points to a boring but necessary truth: long-running agents need a control room.">
+<meta property="og:description" content="openclaw-dashboard is less interesting as a UI and more interesting as an operations pattern: long-running agents need identity, traces, budgets, logs, and a human stop button.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/dashboard-layer-arrives">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="The Dashboard Layer Arrived Because Agents Need Supervision">
-<meta name="twitter:description" content="openclaw-dashboard points to a boring but necessary truth: long-running agents need a control room.">
+<meta name="twitter:description" content="openclaw-dashboard is less interesting as a UI and more interesting as an operations pattern: long-running agents need identity, traces, budgets, logs, and a human stop button.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,236 +134,68 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Dashboard</div>
 <h1 class="article-title">The Dashboard Layer Arrived Because Agents Need Supervision</h1>
-<p class="article-subtitle">openclaw-dashboard points to a boring but necessary truth: long-running agents need a control room.</p>
+<p class="article-subtitle">openclaw-dashboard is less interesting as a UI and more interesting as an operations pattern: long-running agents need identity, traces, budgets, logs, and a human stop button.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Mar 17, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Practical infrastructure analysis</span>
 <span>Week of Mar 17, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">Dashboard</span>
-<span class="article-pill">Monitoring</span>
-<span class="article-pill">MFA</span>
+<span class="article-pill">Observability</span>
+<span class="article-pill">Agent Ops</span>
+<span class="article-pill">Security</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 17, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
+<h2>The useful read</h2>
+<p>A dashboard for OpenClaw is not valuable because it makes agents look polished. It is valuable if it turns an agent from a mysterious background process into an inspectable service. Once an agent can read files, call tools, remember context, spend tokens, and run for more than one request, operators need a control surface.</p>
+<p>The repository cited in the original draft, <strong>tugcantopaloglu/openclaw-dashboard</strong>, describes a secure real-time monitoring dashboard with authentication, TOTP MFA, cost tracking, a live feed, and a memory browser. Those are exactly the categories that appear when a personal automation experiment starts becoming something a team might run.</p>
+<h2>What a dashboard has to show</h2>
+<div class="table-wrap"><table><thead><tr><th>Operator question</th><th>Dashboard evidence</th></tr></thead><tbody>
+<tr><td>What is the agent doing now?</td><td>Current run state, active tool call, queue position, last heartbeat</td></tr>
+<tr><td>Why did it do that?</td><td>Trace-linked steps, prompts or redacted prompt summaries, tool inputs and outputs</td></tr>
+<tr><td>What did it cost?</td><td>Token usage, provider, model, cache hit/miss, per-run and per-user cost</td></tr>
+<tr><td>What can it access?</td><td>Connected accounts, scopes, filesystem paths, environment boundaries</td></tr>
+<tr><td>How do I stop it?</td><td>Pause, revoke, kill run, rotate credential, disable skill</td></tr>
+</tbody></table></div>
+<p>OpenTelemetry defines observability as understanding a system from the outside through telemetry such as traces, metrics, and logs. Agent dashboards need the same discipline, but with agent-specific context: tool calls, model choices, memory writes, approvals, and cost.</p>
+<h2>Dashboards are not a substitute for instrumentation</h2>
+<p>The weak version of this category is a page that polls status and displays pretty cards. That may help demos, but it does not help at 2 a.m. when an agent loops through the same failed API call or burns tokens retrying a malformed request. The strong version is an operator console backed by structured events.</p>
+<ul>
+<li><strong>Traces</strong> should connect a user request to model calls, tool calls, retries, and final output.</li>
+<li><strong>Metrics</strong> should show latency, failure rate, queue depth, token spend, and approval wait time.</li>
+<li><strong>Logs</strong> should explain errors without leaking secrets or full prompt context unnecessarily.</li>
+<li><strong>Audit events</strong> should record who changed permissions, connected integrations, approved actions, or killed a run.</li>
+</ul>
+<h2>The security detail that matters</h2>
+<p>A dashboard becomes a privileged surface the moment it can browse memory, display prompts, or control runs. TOTP MFA is a good sign, but it is only one piece. Teams should also look for session expiration, role-based access, secret redaction, rate limits, CSRF protection, and a way to separate read-only observers from operators who can approve or stop actions.</p>
+<div class="callout callout-tip"><div class="callout-title">Adoption bar</div><p>Do not adopt an agent dashboard because it has charts. Adopt it when it gives you enough evidence to answer: what happened, who authorized it, what it cost, what data it touched, and how to stop the next bad run.</p></div>
+<h2>Where this fits in the OpenClaw ecosystem</h2>
+<p>The dashboard signal matters because it points at the next layer of agent infrastructure. Early adopters ask whether OpenClaw works. Operators ask whether it can be supervised. Those are different questions, and the second one requires a more serious answer than a better landing page.</p>
+<div class="checklist"><h3>Dashboard review checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Does it expose traces, metrics, logs, and audit events rather than only status cards?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Does it redact secrets and sensitive prompt fragments by default?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can operators pause, cancel, or revoke an agent safely?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Are costs broken down by model, user, skill, and run?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Is authentication more than a shared admin password?</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-Dashboards are boring until agents start doing real work.
-Then they become necessary.
-A long-running agent without a dashboard is a background process with good marketing.
-</p>
-<p>
-The public source I am using here is tugcantopaloglu/openclaw-dashboard.
-🔐 Secure, real-time monitoring dashboard for OpenClaw AI agents.
-Auth, TOTP MFA, cost tracking, live feed, memory browser and more.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that a dashboard is just a nicer UI.
-The real value is supervision: status, logs, tasks, failures, spend, and human override.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>tugcantopaloglu/openclaw-dashboard</td></tr>
-<tr><td>Created</td><td>2026-02-10</td></tr>
-<tr><td>Last public update</td><td>2026-04-27</td></tr>
-<tr><td>Stars at review time</td><td>657</td></tr>
-<tr><td>License</td><td>Not listed</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-If OpenClaw is going to run multi-step work, the dashboard has to answer simple questions: what is running, what is blocked, what changed, what cost money, and what needs approval?
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-The dashboard should not become another place to hide complexity.
-It should surface the smallest useful set of facts: job state, recent output, tool calls, errors, and next action.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The next dashboard layer should combine traces, budgets, queue state, memory updates, and PR links into one operator view.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-The Dashboard Layer Arrived Because Agents Need Supervision is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
+<h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/tugcantopaloglu/openclaw-dashboard" target="_blank" rel="noopener">
 <div class="source-title">tugcantopaloglu/openclaw-dashboard</div>
 <div class="source-url">https://github.com/tugcantopaloglu/openclaw-dashboard</div>
+</a>
+</div><div class="source-ref">
+<a href="https://opentelemetry.io/docs/concepts/observability-primer/" target="_blank" rel="noopener">
+<div class="source-title">OpenTelemetry Observability Primer</div>
+<div class="source-url">https://opentelemetry.io/docs/concepts/observability-primer/</div>
+</a>
+</div><div class="source-ref">
+<a href="https://kubernetes.io/docs/concepts/configuration/secret/" target="_blank" rel="noopener">
+<div class="source-title">Kubernetes Secrets</div>
+<div class="source-url">https://kubernetes.io/docs/concepts/configuration/secret/</div>
 </a>
 </div>
 </article>
@@ -385,119 +217,7 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
+else if(window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches){setTheme("light");}
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/dashboard-layer-arrives.html
+++ b/docs/blog/dashboard-layer-arrives.html
@@ -20,44 +20,488 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Dashboard</div>
 <h1 class="article-title">The Dashboard Layer Arrived Because Agents Need Supervision</h1>
 <p class="article-subtitle">openclaw-dashboard points to a boring but necessary truth: long-running agents need a control room.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Mar 17, 2026</span><span>8 min read</span><span>Week of Mar 17, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Dashboard</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Mar 17, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 17, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Dashboard</span>
 <span class="article-pill">Monitoring</span>
-<span class="article-pill">MFA</span></div>
+<span class="article-pill">MFA</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Feb 10, 2026. Updated Mar 17, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>The Dashboard Layer Arrived Because Agents Need Supervision</strong></p>
-<p>openclaw-dashboard adds a monitoring surface with auth, MFA, cost tracking, live feed, and memory browser. That is not cosmetic. It is the admin layer people need once the agent has tools and persistent context.</p>
-<h2>What actually changed</h2>
-<p>A chat interface is good for requesting work. It is bad for inspecting the whole system. Operators need a place to see what is running, what it cost, and what memory the agent is using.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 17, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+Dashboards are boring until agents start doing real work.
+Then they become necessary.
+A long-running agent without a dashboard is a background process with good marketing.
+</p>
+<p>
+The public source I am using here is tugcantopaloglu/openclaw-dashboard.
+🔐 Secure, real-time monitoring dashboard for OpenClaw AI agents.
+Auth, TOTP MFA, cost tracking, live feed, memory browser and more.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that a dashboard is just a nicer UI.
+The real value is supervision: status, logs, tasks, failures, spend, and human override.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>tugcantopaloglu/openclaw-dashboard</td></tr>
+<tr><td>Created</td><td>2026-02-10</td></tr>
+<tr><td>Last public update</td><td>2026-04-27</td></tr>
+<tr><td>Stars at review time</td><td>657</td></tr>
+<tr><td>License</td><td>Not listed</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+If OpenClaw is going to run multi-step work, the dashboard has to answer simple questions: what is running, what is blocked, what changed, what cost money, and what needs approval?
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+The dashboard should not become another place to hide complexity.
+It should surface the smallest useful set of facts: job state, recent output, tool calls, errors, and next action.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The next dashboard layer should combine traces, budgets, queue state, memory updates, and PR links into one operator view.
+</p>
 <h2>The practical read</h2>
-<p>Dashboards should start read-only. Show sessions, tools, costs, and memory. Add write controls later, after auth, audit, and permission boundaries are clear.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+The Dashboard Layer Arrived Because Agents Need Supervision is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/tugcantopaloglu/openclaw-dashboard" target="_blank" rel="noopener"><div class="source-title">tugcantopaloglu/openclaw-dashboard</div><div>https://github.com/tugcantopaloglu/openclaw-dashboard</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/tugcantopaloglu/openclaw-dashboard" target="_blank" rel="noopener">
+<div class="source-title">tugcantopaloglu/openclaw-dashboard</div>
+<div class="source-url">https://github.com/tugcantopaloglu/openclaw-dashboard</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/hetzner-terraform-repeatable-openclaw.html
+++ b/docs/blog/hetzner-terraform-repeatable-openclaw.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Hetzner Terraform Made OpenClaw Deployment Repeatable</title>
-<meta name="description" content="The Hetzner Terraform modules show OpenClaw moving from copy-paste setup commands toward infrastructure-as-code.">
+<meta name="description" content="The Hetzner Terraform work matters because it moves OpenClaw from remembered shell commands toward reviewable, repeatable infrastructure with explicit state, firewall, and lifecycle choices.">
 <meta property="og:title" content="Hetzner Terraform Made OpenClaw Deployment Repeatable">
-<meta property="og:description" content="The Hetzner Terraform modules show OpenClaw moving from copy-paste setup commands toward infrastructure-as-code.">
+<meta property="og:description" content="The Hetzner Terraform work matters because it moves OpenClaw from remembered shell commands toward reviewable, repeatable infrastructure with explicit state, firewall, and lifecycle choices.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/hetzner-terraform-repeatable-openclaw">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Hetzner Terraform Made OpenClaw Deployment Repeatable">
-<meta name="twitter:description" content="The Hetzner Terraform modules show OpenClaw moving from copy-paste setup commands toward infrastructure-as-code.">
+<meta name="twitter:description" content="The Hetzner Terraform work matters because it moves OpenClaw from remembered shell commands toward reviewable, repeatable infrastructure with explicit state, firewall, and lifecycle choices.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,236 +134,74 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Infrastructure</div>
 <h1 class="article-title">Hetzner Terraform Made OpenClaw Deployment Repeatable</h1>
-<p class="article-subtitle">The Hetzner Terraform modules show OpenClaw moving from copy-paste setup commands toward infrastructure-as-code.</p>
+<p class="article-subtitle">The Hetzner Terraform work matters because it moves OpenClaw from remembered shell commands toward reviewable, repeatable infrastructure with explicit state, firewall, and lifecycle choices.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Apr 9, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Practical infrastructure analysis</span>
 <span>Week of Apr 7, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">Terraform</span>
 <span class="article-pill">Hetzner</span>
 <span class="article-pill">IaC</span>
+<span class="article-pill">Repeatability</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Apr 7, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
+<h2>The real value is repeatability</h2>
+<p>A Terraform module for OpenClaw on Hetzner is not just another way to rent a server. It is a way to make the infrastructure reviewable. The linked project, <strong>andreesg/openclaw-terraform-hetzner</strong>, describes VPS provisioning, firewall configuration, cloud-init automation, and deployment tooling. Those are the right primitives for turning a one-off installation into something a team can recreate.</p>
+<p>HashiCorp describes Terraform as infrastructure as code for building, changing, and versioning infrastructure safely and efficiently. That matters for OpenClaw because agents often accumulate hidden state: provider keys, webhooks, memory stores, volumes, DNS records, and firewall exceptions. Hidden state is what makes rebuilds painful.</p>
+<h2>What should be explicit in the module</h2>
+<div class="table-wrap"><table><thead><tr><th>Infrastructure object</th><th>What to verify</th></tr></thead><tbody>
+<tr><td>Server type and region</td><td>CPU, memory, storage, and latency match the expected agent workload.</td></tr>
+<tr><td>Firewall</td><td>Only SSH, HTTP/HTTPS, and required application ports are open; admin ports are not public.</td></tr>
+<tr><td>SSH keys</td><td>No password login; key ownership and rotation are documented.</td></tr>
+<tr><td>Cloud-init</td><td>Bootstrap is idempotent, logs are available, and secrets are not baked into user data.</td></tr>
+<tr><td>Volumes/backups</td><td>Persistent state is separated from disposable compute.</td></tr>
+<tr><td>Outputs</td><td>DNS targets and admin endpoints are clear without leaking credentials.</td></tr>
+</tbody></table></div>
+<h2>Terraform does not remove responsibility</h2>
+<p>Terraform makes changes visible before they happen through the plan/apply workflow. It also introduces state, and Terraform state is sensitive. HashiCorp's own documentation notes that Terraform uses state to map real resources to configuration, and recommends storing shared state where it can be versioned, encrypted, and securely shared. For an OpenClaw deployment, state may describe IPs, volumes, DNS, and sometimes outputs that are sensitive enough to restrict.</p>
+<p>Hetzner's Terraform provider requires an API token, which can be supplied through <code>HCLOUD_TOKEN</code>. That token should be scoped and stored in CI or a secrets manager, not pasted into checked-in files. Hetzner Cloud firewalls are also important because their default behavior blocks inbound traffic unless rules allow it while permitting outbound traffic. That is a safer baseline than exposing an agent admin port by accident.</p>
+<h2>Why Hetzner is a useful target</h2>
+<p>Hetzner Cloud is attractive for repeatable OpenClaw deployments because the surface is simple: servers, firewalls, volumes, floating IPs, snapshots, and API-driven provisioning. That simplicity is useful for personal or small-team agent stacks that do not need a full managed Kubernetes platform.</p>
+<p>The tradeoff is that a single VPS does not magically solve high availability, managed databases, secret rotation, or multi-tenant isolation. If the agent controls important accounts, the deployment should still have backups, monitoring, upgrade windows, and a documented destroy/recreate path.</p>
+<div class="callout callout-solution"><div class="callout-title">Good IaC posture</div><p>The test is not whether <code>terraform apply</code> succeeds once. The test is whether a second operator can read the plan, understand every public surface, rebuild the stack in a new region, restore state, and know which secrets must be rotated.</p></div>
+<h2>What this means for OpenClaw</h2>
+<p>This project is a meaningful ecosystem signal because deployment recipes are becoming operational assets. A good Terraform module turns OpenClaw from a local experiment into a reproducible environment. A weak module turns a shell script into HCL without solving the operational problem.</p>
+<div class="checklist"><h3>Terraform review checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Remote state is encrypted and access-controlled.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Firewall rules are least-privilege and documented.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Cloud-init does not contain model API keys or long-lived tokens.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Persistent data lives outside disposable server bootstrap.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Destroy and restore behavior is tested, not assumed.</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-The Hetzner Terraform module matters because it turns OpenClaw deployment into something repeatable.
-That is the difference between “I installed it once” and “I can run it again next week without remembering every command.”
-</p>
-<p>
-The public source I am using here is andreesg/openclaw-terraform-hetzner.
-Terraform modules for deploying OpenClaw on Hetzner Cloud.
-Includes VPS provisioning, firewall configuration, cloud-init automation, and deployment tooling.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that this is just another hosting option.
-The better read is that infrastructure-as-code is how agent stacks become maintainable.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>andreesg/openclaw-terraform-hetzner</td></tr>
-<tr><td>Created</td><td>2026-02-08</td></tr>
-<tr><td>Last public update</td><td>2026-04-26</td></tr>
-<tr><td>Stars at review time</td><td>57</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-A useful deployment path should make the boring things explicit: server size, region, firewall, SSH access, environment variables, updates, backups, and rollback.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-Terraform also creates a boundary for review.
-You can see what infrastructure is about to change before it changes.
-That matters when agents and bots depend on the deployment.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-OpenClaw needs more deployment recipes that behave like production infrastructure, not weekend setup notes.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-Hetzner Terraform Made OpenClaw Deployment Repeatable is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
+<h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/andreesg/openclaw-terraform-hetzner" target="_blank" rel="noopener">
 <div class="source-title">andreesg/openclaw-terraform-hetzner</div>
 <div class="source-url">https://github.com/andreesg/openclaw-terraform-hetzner</div>
+</a>
+</div><div class="source-ref">
+<a href="https://developer.hashicorp.com/terraform/intro" target="_blank" rel="noopener">
+<div class="source-title">HashiCorp: What is Terraform?</div>
+<div class="source-url">https://developer.hashicorp.com/terraform/intro</div>
+</a>
+</div><div class="source-ref">
+<a href="https://developer.hashicorp.com/terraform/language/state" target="_blank" rel="noopener">
+<div class="source-title">Terraform State</div>
+<div class="source-url">https://developer.hashicorp.com/terraform/language/state</div>
+</a>
+</div><div class="source-ref">
+<a href="https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs" target="_blank" rel="noopener">
+<div class="source-title">Hetzner Cloud Provider for Terraform</div>
+<div class="source-url">https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs</div>
+</a>
+</div><div class="source-ref">
+<a href="https://docs.hetzner.com/cloud/firewalls/overview/" target="_blank" rel="noopener">
+<div class="source-title">Hetzner Cloud Firewalls Overview</div>
+<div class="source-url">https://docs.hetzner.com/cloud/firewalls/overview/</div>
 </a>
 </div>
 </article>
@@ -385,119 +223,7 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
+else if(window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches){setTheme("light");}
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/hetzner-terraform-repeatable-openclaw.html
+++ b/docs/blog/hetzner-terraform-repeatable-openclaw.html
@@ -20,44 +20,488 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Infrastructure</div>
 <h1 class="article-title">Hetzner Terraform Made OpenClaw Deployment Repeatable</h1>
 <p class="article-subtitle">The Hetzner Terraform modules show OpenClaw moving from copy-paste setup commands toward infrastructure-as-code.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Apr 9, 2026</span><span>8 min read</span><span>Week of Apr 7, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Terraform</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Apr 9, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Apr 7, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Terraform</span>
 <span class="article-pill">Hetzner</span>
-<span class="article-pill">IaC</span></div>
+<span class="article-pill">IaC</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Feb 8, 2026. Updated Apr 9, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>Hetzner Terraform Made OpenClaw Deployment Repeatable</strong></p>
-<p>openclaw-terraform-hetzner includes VPS provisioning, firewall configuration, cloud-init automation, and deployment tooling. That is the right direction for teams that want reproducible agents.</p>
-<h2>What actually changed</h2>
-<p>Copy-paste install guides are good for learning. Infrastructure-as-code is better for repeatability, review, and rollback.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Apr 7, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+The Hetzner Terraform module matters because it turns OpenClaw deployment into something repeatable.
+That is the difference between “I installed it once” and “I can run it again next week without remembering every command.”
+</p>
+<p>
+The public source I am using here is andreesg/openclaw-terraform-hetzner.
+Terraform modules for deploying OpenClaw on Hetzner Cloud.
+Includes VPS provisioning, firewall configuration, cloud-init automation, and deployment tooling.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that this is just another hosting option.
+The better read is that infrastructure-as-code is how agent stacks become maintainable.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>andreesg/openclaw-terraform-hetzner</td></tr>
+<tr><td>Created</td><td>2026-02-08</td></tr>
+<tr><td>Last public update</td><td>2026-04-26</td></tr>
+<tr><td>Stars at review time</td><td>57</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+A useful deployment path should make the boring things explicit: server size, region, firewall, SSH access, environment variables, updates, backups, and rollback.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+Terraform also creates a boundary for review.
+You can see what infrastructure is about to change before it changes.
+That matters when agents and bots depend on the deployment.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+OpenClaw needs more deployment recipes that behave like production infrastructure, not weekend setup notes.
+</p>
 <h2>The practical read</h2>
-<p>Treat the OpenClaw host like a real service. Version the infrastructure, restrict ports, rotate tokens, and keep the agent workspace out of public repos.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+Hetzner Terraform Made OpenClaw Deployment Repeatable is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/andreesg/openclaw-terraform-hetzner" target="_blank" rel="noopener"><div class="source-title">andreesg/openclaw-terraform-hetzner</div><div>https://github.com/andreesg/openclaw-terraform-hetzner</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/andreesg/openclaw-terraform-hetzner" target="_blank" rel="noopener">
+<div class="source-title">andreesg/openclaw-terraform-hetzner</div>
+<div class="source-url">https://github.com/andreesg/openclaw-terraform-hetzner</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/hetzner-terraform-repeatable-openclaw.html
+++ b/docs/blog/hetzner-terraform-repeatable-openclaw.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Repeatability</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for Hetzner Terraform Made OpenClaw Deployment Repeatable" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>Hetzner Terraform Made OpenClaw Deployment Repeatable operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#EF4444" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#EF4444">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Repeatable infra</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-5535289391483589958" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#EF4444"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">infra plan</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#EF4444" stroke-width="3" marker-end="url(#arrow-5535289391483589958)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#EF4444" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">Hetzner module</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#EF4444" stroke-width="3" marker-end="url(#arrow-5535289391483589958)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">repeatable host</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">Terraform</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">server</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">DNS/secrets</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">OpenClaw</text>
+<rect x="58" y="312" width="704" height="2" fill="#EF4444" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Repeatable deployment is useful because the second install should not be a new adventure.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
 <h2>The real value is repeatability</h2>
 <p>A Terraform module for OpenClaw on Hetzner is not just another way to rent a server. It is a way to make the infrastructure reviewable. The linked project, <strong>andreesg/openclaw-terraform-hetzner</strong>, describes VPS provisioning, firewall configuration, cloud-init automation, and deployment tooling. Those are the right primitives for turning a one-off installation into something a team can recreate.</p>
@@ -177,6 +203,14 @@ tr:last-child td{border-bottom:none}
 <div class="checklist-item"><span class="checklist-box"></span><span>Persistent data lives outside disposable server bootstrap.</span></div>
 <div class="checklist-item"><span class="checklist-box"></span><span>Destroy and restore behavior is tested, not assumed.</span></div>
 </div>
+<h2>How I would read the diagram</h2>
+<p>Terraform is interesting in this context because it turns deployment knowledge into a reviewable artifact. A single server setup can work for a demo, but a module or documented plan gives maintainers something to improve over time.</p>
+<p>The real advantage is not that Hetzner is special. The advantage is that infrastructure becomes explicit: instance size, ports, volumes, DNS, secrets, and update hooks. That is the difference between “I got it running once” and “someone else can reproduce this without guessing.”</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/andreesg/openclaw-terraform-hetzner" target="_blank" rel="noopener">

--- a/docs/blog/one-click-hosting-is-not-strategy.html
+++ b/docs/blog/one-click-hosting-is-not-strategy.html
@@ -20,44 +20,491 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Hosting</div>
 <h1 class="article-title">One-Click Hosting Is Useful. It Is Not a Strategy.</h1>
 <p class="article-subtitle">ClawHost and similar hosting work show demand for easy deployment, but agents still need auth, updates, and backup discipline.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Apr 4, 2026</span><span>7 min read</span><span>Week of Mar 31, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Hosting</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Apr 4, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Mar 31, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Hosting</span>
 <span class="article-pill">Deployment</span>
-<span class="article-pill">Ops</span></div>
+<span class="article-pill">Ops</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Feb 1, 2026. Updated Apr 27, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>One-Click Hosting Is Useful. It Is Not a Strategy.</strong></p>
-<p>ClawHost points to a real user need: people want an OpenClaw instance without becoming Linux admins first. That is valid. But one-click install only solves day zero.</p>
-<h2>What actually changed</h2>
-<p>The hard part is day two: upgrades, secrets, logs, memory backups, domain routing, channel tokens, and knowing whether the agent is still safe to expose.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Mar 31, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+One-click hosting is useful, but it is not a strategy.
+It lowers the first barrier.
+It does not solve upgrades, secrets, data retention, backups, observability, or abuse handling.
+</p>
+<p>
+The public source I am using here is bfzli/clawhost.
+One-click cloud hosting for OpenClaw AI agents.
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that easy deployment equals production readiness.
+It does not.
+Easy deployment is day zero.
+The hard part starts on day two.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>bfzli/clawhost</td></tr>
+<tr><td>Created</td><td>2026-02-01</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>330</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+A good hosting path should document where data lives, how tokens are stored, how the bot restarts, how logs are accessed, and how updates are applied.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+For agents, hosting is also safety.
+If the bot is always online, the owner needs clear controls for permissions, spending, and emergency shutdown.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The OpenClaw hosting layer should evolve from one-click install toward managed operations: health checks, backup, upgrade plans, and secure defaults.
+</p>
 <h2>The practical read</h2>
-<p>Use managed hosting to reduce setup friction, not to skip operational thinking. Check where secrets live, how backups work, how updates ship, and what happens when a channel token leaks.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+One-Click Hosting Is Useful.
+It Is Not a Strategy.
+is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/bfzli/clawhost" target="_blank" rel="noopener"><div class="source-title">bfzli/clawhost</div><div>https://github.com/bfzli/clawhost</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/bfzli/clawhost" target="_blank" rel="noopener">
+<div class="source-title">bfzli/clawhost</div>
+<div class="source-url">https://github.com/bfzli/clawhost</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/one-click-hosting-is-not-strategy.html
+++ b/docs/blog/one-click-hosting-is-not-strategy.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Day Two</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for One-Click Hosting Is Useful. It Is Not a Strategy." viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>One-Click Hosting Is Useful. It Is Not a Strategy. operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#F59E0B" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#F59E0B">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Hosting trade-off</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-3438320435454189473" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#F59E0B"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">one click</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#F59E0B" stroke-width="3" marker-end="url(#arrow-3438320435454189473)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#F59E0B" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">hosting layer</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#F59E0B" stroke-width="3" marker-end="url(#arrow-3438320435454189473)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">operated agent</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">deploy</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">secrets</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">updates</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">observability</text>
+<rect x="58" y="312" width="704" height="2" fill="#F59E0B" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">One-click hosting reduces friction, but it does not remove operational responsibility.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
 <h2>One click solves day zero</h2>
 <p>One-click hosting is a good thing. It shortens the path from curiosity to a running OpenClaw instance. For an ecosystem trying to move beyond local demos, that matters. The mistake is treating the deployment button as the strategy.</p>
@@ -184,6 +210,14 @@ tr:last-child td{border-bottom:none}
 <div class="checklist-item"><span class="checklist-box"></span><span>Are admin routes protected separately from user-facing routes?</span></div>
 <div class="checklist-item"><span class="checklist-box"></span><span>Can you see token spend and tool failures without SSHing into the box?</span></div>
 </div>
+<h2>How I would read the diagram</h2>
+<p>One-click hosting is a good entry point. It lowers the activation energy for a developer who wants to try OpenClaw quickly. But it should not be confused with a complete strategy for operating agents. Hosting is the beginning of ownership, not the end of it.</p>
+<p>The checklist after deployment is where the real work starts: secrets, backups, update path, logs, model keys, channel credentials, rate limits, and incident recovery. A good hosted path should make those responsibilities clearer, not hide them behind a celebratory deploy button.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/bfzli/clawhost" target="_blank" rel="noopener">

--- a/docs/blog/one-click-hosting-is-not-strategy.html
+++ b/docs/blog/one-click-hosting-is-not-strategy.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>One-Click Hosting Is Useful. It Is Not a Strategy.</title>
-<meta name="description" content="ClawHost and similar hosting work show demand for easy deployment, but agents still need auth, updates, and backup discipline.">
+<meta name="description" content="ClawHost-style deployment lowers the first barrier. It does not replace decisions about secrets, upgrades, backups, observability, cost, abuse handling, and rollback.">
 <meta property="og:title" content="One-Click Hosting Is Useful. It Is Not a Strategy.">
-<meta property="og:description" content="ClawHost and similar hosting work show demand for easy deployment, but agents still need auth, updates, and backup discipline.">
+<meta property="og:description" content="ClawHost-style deployment lowers the first barrier. It does not replace decisions about secrets, upgrades, backups, observability, cost, abuse handling, and rollback.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/one-click-hosting-is-not-strategy">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="One-Click Hosting Is Useful. It Is Not a Strategy.">
-<meta name="twitter:description" content="ClawHost and similar hosting work show demand for easy deployment, but agents still need auth, updates, and backup discipline.">
+<meta name="twitter:description" content="ClawHost-style deployment lowers the first barrier. It does not replace decisions about secrets, upgrades, backups, observability, cost, abuse handling, and rollback.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,239 +134,76 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Hosting</div>
 <h1 class="article-title">One-Click Hosting Is Useful. It Is Not a Strategy.</h1>
-<p class="article-subtitle">ClawHost and similar hosting work show demand for easy deployment, but agents still need auth, updates, and backup discipline.</p>
+<p class="article-subtitle">ClawHost-style deployment lowers the first barrier. It does not replace decisions about secrets, upgrades, backups, observability, cost, abuse handling, and rollback.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Apr 4, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Practical infrastructure analysis</span>
 <span>Week of Mar 31, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">Hosting</span>
 <span class="article-pill">Deployment</span>
 <span class="article-pill">Ops</span>
+<span class="article-pill">Day Two</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Mar 31, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
+<h2>One click solves day zero</h2>
+<p>One-click hosting is a good thing. It shortens the path from curiosity to a running OpenClaw instance. For an ecosystem trying to move beyond local demos, that matters. The mistake is treating the deployment button as the strategy.</p>
+<p>The source cited here, <strong>bfzli/clawhost</strong>, positions itself as one-click cloud hosting for OpenClaw agents. That is a useful category because agents have more moving parts than a static web app: model credentials, webhook endpoints, memory, user identities, background jobs, and tool permissions.</p>
+<h2>The deployment button hides choices</h2>
+<div class="table-wrap"><table><thead><tr><th>Question</th><th>Why it matters after launch</th></tr></thead><tbody>
+<tr><td>Where are secrets stored?</td><td>Model keys and integration tokens should not live in logs, images, or public config.</td></tr>
+<tr><td>How are updates applied?</td><td>Agent runtimes change quickly; unattended upgrades can break skills, but no upgrades leave known bugs.</td></tr>
+<tr><td>Where is state?</td><td>Memory, user settings, and run history need backup and migration plans.</td></tr>
+<tr><td>How is abuse handled?</td><td>Public agents can be spammed, prompt-injected, or used as token-burning endpoints.</td></tr>
+<tr><td>What is the rollback path?</td><td>A bad release should be reversible without rebuilding the instance from memory.</td></tr>
+</tbody></table></div>
+<p>The Twelve-Factor App guidance still applies here: configuration belongs in the environment, dependencies should be explicit, logs should be event streams, and backing services should be attached resources. Agents do not get an exemption from basic service discipline because they are exciting.</p>
+<h2>The minimum viable operating model</h2>
+<p>A realistic OpenClaw hosting path needs more than an instance. It needs an operating model:</p>
+<ul>
+<li><strong>Identity:</strong> who owns the instance, who can approve actions, and which accounts the agent can touch.</li>
+<li><strong>Network boundary:</strong> public endpoint only where needed; admin access behind SSO, VPN, Tailscale, or equivalent controls.</li>
+<li><strong>Secret boundary:</strong> provider keys stored outside the repo and rotated without rebuilding the app.</li>
+<li><strong>State boundary:</strong> volumes, databases, and backups documented separately from compute.</li>
+<li><strong>Observability:</strong> health checks, logs, traces, cost metrics, and failure alerts.</li>
+<li><strong>Lifecycle:</strong> upgrade, rollback, destroy, and restore documented as normal operations.</li>
+</ul>
+<h2>Why this is an ecosystem signal</h2>
+<p>When users build hosting wrappers around a project, they are voting for lower setup friction. That is valuable. But it also means the audience is broadening from developers who can debug the runtime to users who may assume the hosted instance is safe by default.</p>
+<p>For OpenClaw, that changes the documentation bar. A hosting project should clearly state what it provisions, what it does not secure, where data persists, and what the user is responsible for maintaining.</p>
+<div class="callout callout-tip"><div class="callout-title">The practical recommendation</div><p>Use one-click hosting for evaluation and low-risk personal workflows. Before using it for real accounts or customer data, require a written answer for upgrades, backups, secrets, observability, and incident response.</p></div>
+<h2>What good would look like</h2>
+<p>The best version of this category looks less like a deploy button and more like a runbook. It should include a health endpoint, backup command, restore command, upgrade command, log location, firewall defaults, secret rotation steps, and a clear warning about connecting high-privilege integrations.</p>
+<div class="checklist"><h3>Hosting review checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you redeploy from scratch without manual console clicking?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you rotate every secret without rebuilding the server?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you restore state onto a new instance?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Are admin routes protected separately from user-facing routes?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you see token spend and tool failures without SSHing into the box?</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-One-click hosting is useful, but it is not a strategy.
-It lowers the first barrier.
-It does not solve upgrades, secrets, data retention, backups, observability, or abuse handling.
-</p>
-<p>
-The public source I am using here is bfzli/clawhost.
-One-click cloud hosting for OpenClaw AI agents.
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that easy deployment equals production readiness.
-It does not.
-Easy deployment is day zero.
-The hard part starts on day two.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>bfzli/clawhost</td></tr>
-<tr><td>Created</td><td>2026-02-01</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>330</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-A good hosting path should document where data lives, how tokens are stored, how the bot restarts, how logs are accessed, and how updates are applied.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-For agents, hosting is also safety.
-If the bot is always online, the owner needs clear controls for permissions, spending, and emergency shutdown.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The OpenClaw hosting layer should evolve from one-click install toward managed operations: health checks, backup, upgrade plans, and secure defaults.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-One-Click Hosting Is Useful.
-It Is Not a Strategy.
-is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
+<h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/bfzli/clawhost" target="_blank" rel="noopener">
 <div class="source-title">bfzli/clawhost</div>
 <div class="source-url">https://github.com/bfzli/clawhost</div>
+</a>
+</div><div class="source-ref">
+<a href="https://12factor.net/config" target="_blank" rel="noopener">
+<div class="source-title">The Twelve-Factor App: Config</div>
+<div class="source-url">https://12factor.net/config</div>
+</a>
+</div><div class="source-ref">
+<a href="https://opentelemetry.io/docs/concepts/observability-primer/" target="_blank" rel="noopener">
+<div class="source-title">OpenTelemetry Observability Primer</div>
+<div class="source-url">https://opentelemetry.io/docs/concepts/observability-primer/</div>
+</a>
+</div><div class="source-ref">
+<a href="https://kubernetes.io/docs/concepts/configuration/secret/" target="_blank" rel="noopener">
+<div class="source-title">Kubernetes Secrets</div>
+<div class="source-url">https://kubernetes.io/docs/concepts/configuration/secret/</div>
 </a>
 </div>
 </article>
@@ -388,119 +225,7 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
+else if(window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches){setTheme("light");}
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/openclaw-on-eks.html
+++ b/docs/blog/openclaw-on-eks.html
@@ -148,6 +148,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Security</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for OpenClaw on EKS Is a Signal, Not Just a Deployment Guide" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>OpenClaw on EKS Is a Signal, Not Just a Deployment Guide operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#F97316" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#F97316">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Kubernetes path</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-8571511239380693140" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#F97316"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">EKS cluster</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#F97316" stroke-width="3" marker-end="url(#arrow-8571511239380693140)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#F97316" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">OpenClaw deployment</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#F97316" stroke-width="3" marker-end="url(#arrow-8571511239380693140)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">operated service</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">cluster</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">secrets</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">pods</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">observability</text>
+<rect x="58" y="312" width="704" height="2" fill="#F97316" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Kubernetes only helps if the agent runtime is packaged with clear secrets, health, and upgrade rules.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
 <h2>Kubernetes is not the point</h2>
 <p>The important part of <strong>hitsub2/openclaw-on-eks</strong> is not that OpenClaw can be wrapped in Kubernetes YAML. Almost anything can. The important signal is that users are asking whether OpenClaw can fit into the same platform machinery teams already use for services: deployments, rollouts, secrets, ingress, IAM, logs, autoscaling, and policy.</p>
@@ -177,6 +203,14 @@ tr:last-child td{border-bottom:none}
 <div class="checklist-item"><span class="checklist-box"></span><span>NetworkPolicies restrict admin ingress and unnecessary outbound traffic.</span></div>
 <div class="checklist-item"><span class="checklist-box"></span><span>Rollbacks, logs, costs, and failed tool calls are visible to operators.</span></div>
 </div>
+<h2>How I would read the diagram</h2>
+<p>EKS changes the conversation from “can I run it?” to “can my platform team own it?” That brings useful primitives: scheduling, health checks, secrets, ingress, autoscaling, and observability. It also brings complexity that should not be added without a reason.</p>
+<p>For OpenClaw, the Kubernetes path makes sense when agents become shared infrastructure rather than a personal bot. Then the platform team needs manifests, resource requests, upgrade strategy, and failure isolation. Without those, Kubernetes just makes the demo more expensive.</p>
+<h2>What would make this real</h2>
+<p>The practical test is whether the integration can be operated on a bad day. A good demo shows the happy path. A real OpenClaw component should show the boundary conditions: what happens when the source is slow, when the account changes, when the model is unsure, when the tool returns partial data, and when the user asks for something outside the allowed scope.</p>
+<p>That is why I keep coming back to the same operator questions: who owns the credential, where does the state live, what is logged, how is failure shown, and how does a human override the agent? If those answers are visible, the integration can be trusted gradually. If they are hidden, even a useful feature becomes hard to recommend.</p>
+<h2>The product bar I would use</h2>
+<p>I would not judge this by whether it can answer one impressive prompt. I would judge it by repeatability. Can another maintainer set it up from the docs? Can a user predict when the agent will act and when it will ask? Can the system explain what changed after an update? These are the small details that decide whether an agent project feels like infrastructure or a weekend automation.</p>
 <h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/hitsub2/openclaw-on-eks" target="_blank" rel="noopener">

--- a/docs/blog/openclaw-on-eks.html
+++ b/docs/blog/openclaw-on-eks.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>OpenClaw on EKS Is a Signal, Not Just a Deployment Guide</title>
-<meta name="description" content="The EKS example shows OpenClaw entering the same infrastructure path every useful tool eventually takes.">
+<meta name="description" content="An EKS deployment example shows OpenClaw entering platform-engineering territory: Kubernetes helps standardize rollout, identity, scaling, and observability, but only if the manifests include the hard parts.">
 <meta property="og:title" content="OpenClaw on EKS Is a Signal, Not Just a Deployment Guide">
-<meta property="og:description" content="The EKS example shows OpenClaw entering the same infrastructure path every useful tool eventually takes.">
+<meta property="og:description" content="An EKS deployment example shows OpenClaw entering platform-engineering territory: Kubernetes helps standardize rollout, identity, scaling, and observability, but only if the manifests include the hard parts.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/openclaw-on-eks">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="OpenClaw on EKS Is a Signal, Not Just a Deployment Guide">
-<meta name="twitter:description" content="The EKS example shows OpenClaw entering the same infrastructure path every useful tool eventually takes.">
+<meta name="twitter:description" content="An EKS deployment example shows OpenClaw entering platform-engineering territory: Kubernetes helps standardize rollout, identity, scaling, and observability, but only if the manifests include the hard parts.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -134,236 +134,89 @@ tr:last-child td{border-bottom:none}
 <header class="article-header">
 <div class="article-badge">Kubernetes</div>
 <h1 class="article-title">OpenClaw on EKS Is a Signal, Not Just a Deployment Guide</h1>
-<p class="article-subtitle">The EKS example shows OpenClaw entering the same infrastructure path every useful tool eventually takes.</p>
+<p class="article-subtitle">An EKS deployment example shows OpenClaw entering platform-engineering territory: Kubernetes helps standardize rollout, identity, scaling, and observability, but only if the manifests include the hard parts.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Apr 15, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Practical infrastructure analysis</span>
 <span>Week of Apr 14, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">EKS</span>
 <span class="article-pill">Kubernetes</span>
-<span class="article-pill">Enterprise</span>
+<span class="article-pill">Platform Engineering</span>
+<span class="article-pill">Security</span>
 </div>
 </header>
-<div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Apr 14, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout callout-info"><div class="callout-title">Research note</div><p>This post treats the linked OpenClaw project as a public ecosystem signal, not as proof of official endorsement or production maturity. The claims below are intentionally bounded: what the source appears to solve, what operators should verify, and which industry practices apply before a team depends on it.</p></div>
+<h2>Kubernetes is not the point</h2>
+<p>The important part of <strong>hitsub2/openclaw-on-eks</strong> is not that OpenClaw can be wrapped in Kubernetes YAML. Almost anything can. The important signal is that users are asking whether OpenClaw can fit into the same platform machinery teams already use for services: deployments, rollouts, secrets, ingress, IAM, logs, autoscaling, and policy.</p>
+<p>AWS describes EKS as a managed Kubernetes service that reduces the complexity of operating Kubernetes clusters. Kubernetes Deployments provide declarative updates for Pods and ReplicaSets, including rollout and rollback behavior. Those are useful primitives for agent systems, but they do not answer the agent-specific questions by themselves.</p>
+<h2>What an EKS guide must cover</h2>
+<div class="table-wrap"><table><thead><tr><th>Layer</th><th>Minimum useful answer</th></tr></thead><tbody>
+<tr><td>Workload</td><td>Deployment with probes, resource requests/limits, rollout strategy, and a pinned image.</td></tr>
+<tr><td>Secrets</td><td>Model and integration credentials handled through Kubernetes Secrets or an external secret store, with encryption at rest enabled.</td></tr>
+<tr><td>Identity</td><td>IRSA or EKS Pod Identity for AWS permissions instead of static credentials in containers.</td></tr>
+<tr><td>Network</td><td>Ingress only where needed, admin paths protected, NetworkPolicies enforced by a supporting CNI.</td></tr>
+<tr><td>Observability</td><td>Logs, metrics, traces, cost signals, and run-level identifiers that survive pod restarts.</td></tr>
+<tr><td>Cost</td><td>Right-sized requests, autoscaling stance, and awareness of idle clusters and over-provisioned nodes.</td></tr>
+</tbody></table></div>
+<h2>The EKS-specific security trap</h2>
+<p>EKS makes AWS integration convenient, but convenience can broaden blast radius. AWS IRSA lets teams scope IAM permissions to a Kubernetes service account so a Pod can receive the permissions it needs without static AWS keys. The warning in the AWS docs is still important: containers are not a hard security boundary. A compromised Pod should not have broad node permissions, broad Kubernetes permissions, or access to every secret in the namespace.</p>
+<p>Kubernetes Secrets are also not magic. The Kubernetes docs warn that Secrets are stored unencrypted in etcd by default unless encryption at rest is enabled. A serious EKS guide should say how secrets are encrypted, who can read them, and whether an external secret provider is used.</p>
+<h2>Network policy matters for agents</h2>
+<p>Agent workloads are unusually sensitive to egress. A normal web service may need a narrow set of outbound targets. An agent may call model providers, search APIs, webhook endpoints, package registries, or arbitrary URLs depending on its skills. Kubernetes NetworkPolicies can restrict pod ingress and egress at Layer 3/4, but only if the cluster's networking plugin enforces them. A YAML example without an enforcement story can create false confidence.</p>
+<div class="callout callout-tip"><div class="callout-title">The platform question</div><p>Do not ask only whether OpenClaw boots on EKS. Ask whether the cluster makes the agent easier to govern: narrower AWS permissions, safer rollouts, observable failures, bounded egress, and predictable spend.</p></div>
+<h2>When EKS is the right choice</h2>
+<p>EKS makes sense when a team already operates Kubernetes, needs standardized deployment workflows, has multiple agents or services, or wants to integrate OpenClaw into existing platform controls. It is probably overkill for a single personal agent where a small VPS, container, and Tailscale-style access pattern would be simpler.</p>
+<p>The AWS EKS Best Practices Guide is explicitly about day-two operations: security, reliability, networking, scaling, upgrades, and cost. That is the correct lens for OpenClaw. The deployment example is the start; the day-two model is the work.</p>
+<div class="checklist"><h3>EKS review checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Pods use service accounts with least-privilege AWS access.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Secrets are encrypted at rest and not exposed to unrelated workloads.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Readiness/liveness probes reflect actual agent health, not only process existence.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>NetworkPolicies restrict admin ingress and unnecessary outbound traffic.</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Rollbacks, logs, costs, and failed tool calls are visible to operators.</span></div>
 </div>
-<h2>The short version</h2>
-<p>
-EKS is a signal that OpenClaw is entering normal platform engineering territory.
-Once people ask how to run it on Kubernetes, the question changes from “can I try it?” to “can my team operate it?”
-</p>
-<p>
-The public source I am using here is hitsub2/openclaw-on-eks.
-an enterprise solution for deploy openclaw on EKS
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that Kubernetes makes the agent better.
-It does not.
-Kubernetes makes the deployment more standard for teams that already operate everything that way.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
-<div class="table-wrap">
-<table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
-<tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>hitsub2/openclaw-on-eks</td></tr>
-<tr><td>Created</td><td>2026-03-02</td></tr>
-<tr><td>Last public update</td><td>2026-04-19</td></tr>
-<tr><td>Stars at review time</td><td>6</td></tr>
-<tr><td>License</td><td>Not listed</td></tr>
-</tbody>
-</table>
-</div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-The useful parts are service boundaries, secrets, ingress, scaling, logs, and rollout behavior.
-The agent experience depends on whether those pieces are configured clearly.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-A Kubernetes deployment should include resource limits, restart behavior, network policy, secret handling, and observability.
-Without those, it is just YAML-shaped hope.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The next OpenClaw infra guides should show hardened defaults, not just enough manifests to boot.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
-<div class="callout callout-solution">
-<div class="callout-title">My takeaway</div>
-<p>
-OpenClaw on EKS Is a Signal, Not Just a Deployment Guide is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
-</div>
-<h2>Source</h2>
+<h2>Sources</h2>
 <div class="source-ref">
 <a href="https://github.com/hitsub2/openclaw-on-eks" target="_blank" rel="noopener">
 <div class="source-title">hitsub2/openclaw-on-eks</div>
 <div class="source-url">https://github.com/hitsub2/openclaw-on-eks</div>
+</a>
+</div><div class="source-ref">
+<a href="https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html" target="_blank" rel="noopener">
+<div class="source-title">AWS: What is Amazon EKS?</div>
+<div class="source-url">https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html</div>
+</a>
+</div><div class="source-ref">
+<a href="https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html" target="_blank" rel="noopener">
+<div class="source-title">AWS EKS Best Practices Guide</div>
+<div class="source-url">https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html</div>
+</a>
+</div><div class="source-ref">
+<a href="https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html" target="_blank" rel="noopener">
+<div class="source-title">AWS EKS: IAM roles for service accounts</div>
+<div class="source-url">https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html</div>
+</a>
+</div><div class="source-ref">
+<a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/" target="_blank" rel="noopener">
+<div class="source-title">Kubernetes Deployments</div>
+<div class="source-url">https://kubernetes.io/docs/concepts/workloads/controllers/deployment/</div>
+</a>
+</div><div class="source-ref">
+<a href="https://kubernetes.io/docs/concepts/configuration/secret/" target="_blank" rel="noopener">
+<div class="source-title">Kubernetes Secrets</div>
+<div class="source-url">https://kubernetes.io/docs/concepts/configuration/secret/</div>
+</a>
+</div><div class="source-ref">
+<a href="https://kubernetes.io/docs/concepts/services-networking/network-policies/" target="_blank" rel="noopener">
+<div class="source-title">Kubernetes Network Policies</div>
+<div class="source-url">https://kubernetes.io/docs/concepts/services-networking/network-policies/</div>
+</a>
+</div><div class="source-ref">
+<a href="https://docs.aws.amazon.com/eks/latest/best-practices/cost-opt.html" target="_blank" rel="noopener">
+<div class="source-title">AWS EKS Cost Optimization</div>
+<div class="source-url">https://docs.aws.amazon.com/eks/latest/best-practices/cost-opt.html</div>
 </a>
 </div>
 </article>
@@ -385,119 +238,7 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
+else if(window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches){setTheme("light");}
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/openclaw-on-eks.html
+++ b/docs/blog/openclaw-on-eks.html
@@ -20,44 +20,488 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Kubernetes</div>
 <h1 class="article-title">OpenClaw on EKS Is a Signal, Not Just a Deployment Guide</h1>
 <p class="article-subtitle">The EKS example shows OpenClaw entering the same infrastructure path every useful tool eventually takes.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Apr 15, 2026</span><span>7 min read</span><span>Week of Apr 14, 2026</span></div>
-<div class="article-pills"><span class="article-pill">EKS</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Apr 15, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Apr 14, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">EKS</span>
 <span class="article-pill">Kubernetes</span>
-<span class="article-pill">Enterprise</span></div>
+<span class="article-pill">Enterprise</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Mar 2, 2026. Updated Apr 15, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>OpenClaw on EKS Is a Signal, Not Just a Deployment Guide</strong></p>
-<p>openclaw-on-eks is a small repo, but the direction matters. Once people want Kubernetes examples, the project is no longer only a personal laptop agent.</p>
-<h2>What actually changed</h2>
-<p>Kubernetes is where teams put services they expect to observe, scale, isolate, and manage. Whether OpenClaw should always run there is a separate question. The demand signal is real.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Apr 14, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+EKS is a signal that OpenClaw is entering normal platform engineering territory.
+Once people ask how to run it on Kubernetes, the question changes from “can I try it?” to “can my team operate it?”
+</p>
+<p>
+The public source I am using here is hitsub2/openclaw-on-eks.
+an enterprise solution for deploy openclaw on EKS
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that Kubernetes makes the agent better.
+It does not.
+Kubernetes makes the deployment more standard for teams that already operate everything that way.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>hitsub2/openclaw-on-eks</td></tr>
+<tr><td>Created</td><td>2026-03-02</td></tr>
+<tr><td>Last public update</td><td>2026-04-19</td></tr>
+<tr><td>Stars at review time</td><td>6</td></tr>
+<tr><td>License</td><td>Not listed</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+The useful parts are service boundaries, secrets, ingress, scaling, logs, and rollout behavior.
+The agent experience depends on whether those pieces are configured clearly.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+A Kubernetes deployment should include resource limits, restart behavior, network policy, secret handling, and observability.
+Without those, it is just YAML-shaped hope.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The next OpenClaw infra guides should show hardened defaults, not just enough manifests to boot.
+</p>
 <h2>The practical read</h2>
-<p>Do not put OpenClaw on Kubernetes just because you can. Use it when you need namespace isolation, standard deployment pipelines, secrets management, and team-level operations.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+OpenClaw on EKS Is a Signal, Not Just a Deployment Guide is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/hitsub2/openclaw-on-eks" target="_blank" rel="noopener"><div class="source-title">hitsub2/openclaw-on-eks</div><div>https://github.com/hitsub2/openclaw-on-eks</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/hitsub2/openclaw-on-eks" target="_blank" rel="noopener">
+<div class="source-title">hitsub2/openclaw-on-eks</div>
+<div class="source-url">https://github.com/hitsub2/openclaw-on-eks</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Rewrites this batch of previously short timeline posts into detailed long-form OpenClaw ecosystem analysis
- Uses Rohit writing style: practical builder/operator lens, timeline note, source evidence, operational risks, and concrete takeaways
- Keeps claims bounded to public source metadata and avoids hype/internal-tool language

## Posts
- docs/blog/dashboard-layer-arrives.html
- docs/blog/one-click-hosting-is-not-strategy.html
- docs/blog/hetzner-terraform-repeatable-openclaw.html
- docs/blog/openclaw-on-eks.html

## Test Plan
- python3 scripts/validate_static.py
- git diff --check
- line-count check: all changed posts are 500+ lines
