### PR TITLE
docs: expand April OpenClaw release and training blog posts

### DIFF
--- a/docs/blog/openclaw-rl-conversational-training.html
+++ b/docs/blog/openclaw-rl-conversational-training.html
@@ -147,6 +147,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">OpenClaw-RL</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for OpenClaw-RL Turns Conversation Into a Training Surface" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>OpenClaw-RL Turns Conversation Into a Training Surface operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#8B5CF6" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#8B5CF6">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Training feedback loop</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-746762713385900514" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#8B5CF6"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">agent run</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#8B5CF6" stroke-width="3" marker-end="url(#arrow-746762713385900514)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#8B5CF6" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">RL loop</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#8B5CF6" stroke-width="3" marker-end="url(#arrow-746762713385900514)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">improved behavior</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">conversation</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">judge</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">reward</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">policy update</text>
+<rect x="58" y="312" width="704" height="2" fill="#8B5CF6" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">Conversational training is powerful only when feedback, privacy, and evaluation are designed together.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info">
 <div class="callout-title">Evidence used</div>
 <p>This post is based on the public <a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener">Gen-Verse/OpenClaw-RL</a> repository, the arXiv paper <a href="https://arxiv.org/abs/2603.10165" target="_blank" rel="noopener">“OpenClaw-RL: Train Any Agent Simply by Talking”</a>, the project page, and related infrastructure references from THUDM slime and Thinking Machines Tinker. I am not adding adoption claims beyond those sources.</p>
@@ -204,6 +230,9 @@ tr:last-child td{border-bottom:none}
 <div class="callout-title">My takeaway</div>
 <p>OpenClaw-RL is interesting because it treats feedback as an operational system, not as a marketing phrase. The right response is not to hype “agents that learn from chat.” The right response is to inspect the data path, judge path, training path, and rollback path before letting conversational traces update a model.</p>
 </div>
+<h2>How I would read the diagram</h2>
+<p>The reason this topic needs a careful read is that learning from conversations sounds obvious until you operate it. A chat transcript can contain useful feedback, private data, bad instructions, sarcasm, and accidental success. Turning that into a training signal requires more than saving messages.</p>
+<p>The promising part of OpenClaw-RL is the framing: ordinary interaction can become a source of improvement. The dangerous part is the same thing. A serious implementation needs judges, privacy boundaries, opt-in controls, rollback paths, and evaluation before the loop is trusted.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener"><div class="source-title">Gen-Verse/OpenClaw-RL</div><div class="source-url">https://github.com/Gen-Verse/OpenClaw-RL</div></a></div>
 <div class="source-ref"><a href="https://arxiv.org/abs/2603.10165" target="_blank" rel="noopener"><div class="source-title">OpenClaw-RL: Train Any Agent Simply by Talking</div><div class="source-url">https://arxiv.org/abs/2603.10165</div></a></div>

--- a/docs/blog/openclaw-rl-conversational-training.html
+++ b/docs/blog/openclaw-rl-conversational-training.html
@@ -20,44 +20,488 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Research</div>
 <h1 class="article-title">OpenClaw-RL Points Toward Conversational Training Loops</h1>
 <p class="article-subtitle">OpenClaw-RL is not another channel plugin. It asks a deeper question: can agents improve from conversational feedback?</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Apr 21, 2026</span><span>8 min read</span><span>Week of Apr 21, 2026</span></div>
-<div class="article-pills"><span class="article-pill">RL</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Apr 21, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Apr 21, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">RL</span>
 <span class="article-pill">Training</span>
-<span class="article-pill">Agents</span></div>
+<span class="article-pill">Agents</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>Created Feb 26, 2026. Updated Apr 21, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>OpenClaw-RL Points Toward Conversational Training Loops</strong></p>
-<p>OpenClaw-RL describes itself as training any agent simply by talking. The implementation and claims need normal technical scrutiny, but the direction is worth watching.</p>
-<h2>What actually changed</h2>
-<p>Most agent feedback today is informal. A user says good job, wrong, try again, or do it like this next time. Turning that into durable improvement is one of the hardest useful problems in agents.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Apr 21, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+OpenClaw-RL is a deeper signal than another plugin.
+It points at conversational training loops: agents learning from correction, preference, and repeated workflows.
+</p>
+<p>
+The public source I am using here is Gen-Verse/OpenClaw-RL.
+OpenClaw-RL: Train any agent simply by talking
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The shallow read is “RL will make the agent smarter.” The useful read is narrower: feedback needs to become structured enough that a system can improve from it.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>Gen-Verse/OpenClaw-RL</td></tr>
+<tr><td>Created</td><td>2026-02-26</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>5157</td></tr>
+<tr><td>License</td><td>Apache-2.0</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+The practical question is what counts as feedback.
+A thumbs-up is weak.
+A corrected command, a rejected patch, or a rewritten answer is much more useful.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+Training loops need guardrails.
+You do not want an agent learning from every noisy chat message or one-off preference.
+You need review, versioning, and rollback.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The most useful future agent systems will separate immediate task execution from slower learning pipelines.
+</p>
 <h2>The practical read</h2>
-<p>Keep a hard line between feedback, memory, and model training. Feedback can improve workflows immediately. Training loops need evaluation, rollback, and protection from poisoned examples.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+OpenClaw-RL Points Toward Conversational Training Loops is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener"><div class="source-title">Gen-Verse/OpenClaw-RL</div><div>https://github.com/Gen-Verse/OpenClaw-RL</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener">
+<div class="source-title">Gen-Verse/OpenClaw-RL</div>
+<div class="source-url">https://github.com/Gen-Verse/OpenClaw-RL</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>

--- a/docs/blog/openclaw-rl-conversational-training.html
+++ b/docs/blog/openclaw-rl-conversational-training.html
@@ -3,16 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>OpenClaw-RL Points Toward Conversational Training Loops</title>
-<meta name="description" content="OpenClaw-RL is not another channel plugin. It asks a deeper question: can agents improve from conversational feedback?">
-<meta property="og:title" content="OpenClaw-RL Points Toward Conversational Training Loops">
-<meta property="og:description" content="OpenClaw-RL is not another channel plugin. It asks a deeper question: can agents improve from conversational feedback?">
+<title>OpenClaw-RL Turns Conversation Into a Training Surface</title>
+<meta name="description" content="A researched read on OpenClaw-RL: asynchronous agent training, next-state feedback, OPD, process rewards, and what builders should verify before using it.">
+<meta property="og:title" content="OpenClaw-RL Turns Conversation Into a Training Surface">
+<meta property="og:description" content="A researched read on OpenClaw-RL: asynchronous agent training, next-state feedback, OPD, process rewards, and what builders should verify before using it.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/openclaw-rl-conversational-training">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="OpenClaw-RL Points Toward Conversational Training Loops">
-<meta name="twitter:description" content="OpenClaw-RL is not another channel plugin. It asks a deeper question: can agents improve from conversational feedback?">
+<meta name="twitter:title" content="OpenClaw-RL Turns Conversation Into a Training Surface">
+<meta name="twitter:description" content="A researched read on OpenClaw-RL: asynchronous agent training, next-state feedback, OPD, process rewards, and what builders should verify before using it.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -133,239 +133,83 @@ tr:last-child td{border-bottom:none}
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Research</div>
-<h1 class="article-title">OpenClaw-RL Points Toward Conversational Training Loops</h1>
-<p class="article-subtitle">OpenClaw-RL is not another channel plugin. It asks a deeper question: can agents improve from conversational feedback?</p>
+<h1 class="article-title">OpenClaw-RL Turns Conversation Into a Training Surface</h1>
+<p class="article-subtitle">The interesting claim is not that a chatbot can be “trained by talking.” It is that ordinary agent traces can become structured next-state feedback without stopping the assistant from serving users.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Apr 21, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Research note</span>
 <span>Week of Apr 21, 2026</span>
 </div>
 <div class="article-pills">
 <span class="article-pill">RL</span>
-<span class="article-pill">Training</span>
-<span class="article-pill">Agents</span>
+<span class="article-pill">Agent training</span>
+<span class="article-pill">OpenClaw-RL</span>
 </div>
 </header>
 <div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Apr 21, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout-title">Evidence used</div>
+<p>This post is based on the public <a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener">Gen-Verse/OpenClaw-RL</a> repository, the arXiv paper <a href="https://arxiv.org/abs/2603.10165" target="_blank" rel="noopener">“OpenClaw-RL: Train Any Agent Simply by Talking”</a>, the project page, and related infrastructure references from THUDM slime and Thinking Machines Tinker. I am not adding adoption claims beyond those sources.</p>
 </div>
-<h2>The short version</h2>
-<p>
-OpenClaw-RL is a deeper signal than another plugin.
-It points at conversational training loops: agents learning from correction, preference, and repeated workflows.
-</p>
-<p>
-The public source I am using here is Gen-Verse/OpenClaw-RL.
-OpenClaw-RL: Train any agent simply by talking
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The shallow read is “RL will make the agent smarter.” The useful read is narrower: feedback needs to become structured enough that a system can improve from it.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
+<h2>The useful read</h2>
+<p>OpenClaw-RL is best read as a proposal for turning <strong>agent use</strong> into <strong>agent training data</strong>. The paper’s central observation is simple and practical: after an agent acts, something happens next. A user replies, a command exits, a test passes or fails, a GUI changes state, or a tool returns an error. OpenClaw-RL calls that follow-up a <strong>next-state signal</strong>.</p>
+<p>That framing matters because it avoids a common trap in agent training. If every workflow needs a separate annotation pipeline, only large labs can improve deployed agents. If the interaction trace itself contains usable feedback, smaller teams can at least begin to collect learning signals from the places where agents already run.</p>
+<h2>What the source actually says</h2>
 <div class="table-wrap">
 <table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
+<thead><tr><th>Item</th><th>Public evidence</th></tr></thead>
 <tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>Gen-Verse/OpenClaw-RL</td></tr>
-<tr><td>Created</td><td>2026-02-26</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>5157</td></tr>
-<tr><td>License</td><td>Apache-2.0</td></tr>
+<tr><td>Repository</td><td><a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener">Gen-Verse/OpenClaw-RL</a></td></tr>
+<tr><td>Paper</td><td>arXiv:2603.10165, submitted Mar 10, 2026</td></tr>
+<tr><td>License</td><td>Apache-2.0 in the GitHub repository</td></tr>
+<tr><td>Implementation</td><td>Primarily Python, with shell/C++/CUDA support shown by GitHub</td></tr>
+<tr><td>Positioning</td><td>“Train any agent simply by talking” and “scalable RL in real-world settings”</td></tr>
+<tr><td>Related frameworks</td><td>slime for RL scaling; Tinker for training API infrastructure</td></tr>
 </tbody>
 </table>
 </div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-The practical question is what counts as feedback.
-A thumbs-up is weak.
-A corrected command, a rejected patch, or a rewritten answer is much more useful.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-Training loops need guardrails.
-You do not want an agent learning from every noisy chat message or one-off preference.
-You need review, versioning, and rollback.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
+<h2>The architecture is the point</h2>
+<p>The strongest part of the design is not the slogan. It is the asynchronous separation between serving, collecting trajectories, judging, and training. The project describes a four-component loop: <strong>agent serving</strong>, <strong>rollout collection</strong>, <strong>PRM or judge evaluation</strong>, and <strong>policy training</strong>. Those pieces run independently so the assistant can continue answering while feedback is scored and training jobs run in the background.</p>
+<p>That is the right constraint for personal agents. A deployed assistant cannot pause every time the training stack needs to label a trace. If learning makes the product slower or unreliable, users will disable it. OpenClaw-RL’s practical bet is that training has to be downstream of usage, not in the hot path of every message.</p>
+<h2>Two kinds of feedback</h2>
+<p>The paper separates next-state signals into two categories. <strong>Evaluative feedback</strong> says whether the previous action worked. A user approval, a failed command, or a passing test can become a scalar reward. The OpenClaw-RL materials describe using a process reward model or judge to turn those signals into binary or ternary rewards such as good, bad, or neutral.</p>
+<p><strong>Directive feedback</strong> is richer. A correction like “No, use the staging database” does not merely say the previous answer was wrong; it tells the model what should have changed. OpenClaw-RL’s On-Policy Distillation path, described as OPD, extracts hindsight hints from that next state and uses them to create a more directional training signal.</p>
+<div class="callout callout-tip">
+<div class="callout-title">Why this distinction matters</div>
+<p>A thumbs-down can help a reward model rank behavior. A correction can teach the policy what information was missing. Serious conversational training needs both, and should not pretend that all feedback has the same value.</p>
+</div>
+<h2>Why this is relevant to OpenClaw</h2>
+<p>OpenClaw is a local-first personal assistant that connects to real channels and tools. That creates a different training surface from a web chatbot. It sees multi-turn conversations, tool calls, browser or terminal outcomes, and messaging-channel context. Those traces are exactly the kind of next-state signals OpenClaw-RL is trying to organize.</p>
+<p>This also explains why OpenClaw-RL is not just another plugin. A plugin changes where an agent can run. A training loop changes what the system can learn from once it is running. That is a deeper operating question: what feedback is safe to store, who approves it, how models are versioned, and how a bad update is rolled back.</p>
+<h2>The risks are not theoretical</h2>
+<p>Live learning from personal interactions is sensitive. The repository and project page emphasize self-hosting and privacy: the model, judge, trainer, and data can live on user-controlled infrastructure. That is the right default, but it does not remove the hard parts. Conversation data may contain credentials, private messages, personal preferences, and mistakes that should not become permanent model behavior.</p>
+<p>There is also a data-quality problem. Re-queries, sarcasm, channel noise, and ambiguous tool failures are not clean labels. A user asking again may mean the model failed, or it may mean the user changed the goal. A terminal error may be the agent’s fault, the environment’s fault, or a missing dependency. Any adoption plan needs a review layer before turning traces into training updates.</p>
+<h2>How I would evaluate it before trusting it</h2>
 <div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
+<h3>Builder checklist</h3>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you inspect exactly which conversations and tool traces become training samples?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Is there a clear distinction between logs, candidate training data, approved data, and discarded data?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Can you disable learning for specific channels, users, workspaces, or tools?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Are judge prompts, reward thresholds, and majority-vote behavior auditable?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Is every trained policy version traceable to data and rollback metadata?</span></div>
+<div class="checklist-item"><span class="checklist-box"></span><span>Does serving continue safely if the trainer, judge, or rollout queue fails?</span></div>
 </div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
-<h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The most useful future agent systems will separate immediate task execution from slower learning pipelines.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
+<h2>What this does not prove</h2>
+<p>OpenClaw-RL does not prove that every personal agent should continuously fine-tune itself. It does not prove that noisy conversational feedback beats curated evaluation. It does not remove the need for redaction, evaluation sets, holdout workflows, and human approval for sensitive domains.</p>
+<p>The honest claim is narrower: the project makes a credible research case that ordinary agent interactions contain reusable feedback, and it provides an open implementation path for experimenting with that idea in OpenClaw-like environments.</p>
+<h2>The broader context</h2>
+<p>The related infrastructure references are useful signals. THUDM’s slime is an RL post-training framework that combines high-performance training and flexible rollout/data generation. Thinking Machines’ Tinker exposes training primitives such as forward/backward, sampling, optimizer steps, and state saving while hiding some infrastructure burden. OpenClaw-RL sits closer to the application edge: it asks how those training ideas meet a real assistant that is already talking to users and tools.</p>
+<p>That is why the project is worth tracking. The next generation of agent systems will need a boundary between <strong>immediate execution</strong> and <strong>slower learning</strong>. OpenClaw-RL is one concrete attempt to draw that boundary.</p>
 <div class="callout callout-solution">
 <div class="callout-title">My takeaway</div>
-<p>
-OpenClaw-RL Points Toward Conversational Training Loops is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
+<p>OpenClaw-RL is interesting because it treats feedback as an operational system, not as a marketing phrase. The right response is not to hype “agents that learn from chat.” The right response is to inspect the data path, judge path, training path, and rollback path before letting conversational traces update a model.</p>
 </div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener">
-<div class="source-title">Gen-Verse/OpenClaw-RL</div>
-<div class="source-url">https://github.com/Gen-Verse/OpenClaw-RL</div>
-</a>
-</div>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/Gen-Verse/OpenClaw-RL" target="_blank" rel="noopener"><div class="source-title">Gen-Verse/OpenClaw-RL</div><div class="source-url">https://github.com/Gen-Verse/OpenClaw-RL</div></a></div>
+<div class="source-ref"><a href="https://arxiv.org/abs/2603.10165" target="_blank" rel="noopener"><div class="source-title">OpenClaw-RL: Train Any Agent Simply by Talking</div><div class="source-url">https://arxiv.org/abs/2603.10165</div></a></div>
+<div class="source-ref"><a href="https://yinjjiew.github.io/projects/openclawrl1" target="_blank" rel="noopener"><div class="source-title">OpenClaw-RL project page</div><div class="source-url">https://yinjjiew.github.io/projects/openclawrl1</div></a></div>
+<div class="source-ref"><a href="https://github.com/THUDM/slime" target="_blank" rel="noopener"><div class="source-title">THUDM/slime</div><div class="source-url">https://github.com/THUDM/slime</div></a></div>
+<div class="source-ref"><a href="https://thinkingmachines.ai/tinker/" target="_blank" rel="noopener"><div class="source-title">Thinking Machines Tinker</div><div class="source-url">https://thinkingmachines.ai/tinker/</div></a></div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -385,119 +229,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/v2026-4-25-release-cadence.html
+++ b/docs/blog/v2026-4-25-release-cadence.html
@@ -147,6 +147,32 @@ tr:last-child td{border-bottom:none}
 <span class="article-pill">Operations</span>
 </div>
 </header>
+
+<figure class="post-diagram" style="margin:36px 0;padding:18px;border:1px solid var(--card-border);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));overflow:hidden">
+<svg role="img" aria-label="Diagram for OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle" viewBox="0 0 820 360" width="100%" style="display:block;border-radius:18px;background:#070707" xmlns="http://www.w3.org/2000/svg">
+<title>OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle operating map</title>
+<rect width="820" height="360" fill="#070707"/>
+<circle cx="72" cy="64" r="30" fill="#3B82F6" opacity=".16"/><text x="72" y="71" text-anchor="middle" font-family="Inter,Arial" font-size="26" font-weight="800" fill="#3B82F6">1</text>
+<text x="120" y="58" font-family="Inter,Arial" font-size="24" font-weight="800" fill="#f5f5f5">Release cadence</text>
+<text x="120" y="84" font-family="JetBrains Mono,monospace" font-size="15" fill="#c7c7c7">read it as an operating boundary, not a logo announcement</text>
+<defs><marker id="arrow-8743898629438173840" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L10,3 L0,6 Z" fill="#3B82F6"/></marker></defs>
+<rect x="58" y="134" width="188" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="152" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="18" font-weight="800" fill="#fff">new version</text>
+<text x="152" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">input / source</text>
+<line x1="256" y1="175" x2="342" y2="175" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow-8743898629438173840)"/>
+<rect x="352" y="120" width="212" height="110" rx="22" fill="#111" stroke="#3B82F6" stroke-width="2"/>
+<text x="458" y="164" text-anchor="middle" font-family="Inter,Arial" font-size="19" font-weight="900" fill="#fff">maintenance loop</text>
+<text x="458" y="193" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#d6d6d6">policy • state • logs</text>
+<line x1="574" y1="175" x2="646" y2="175" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow-8743898629438173840)"/>
+<rect x="656" y="134" width="106" height="82" rx="18" fill="#0f0f0f" stroke="#2a2a2a"/>
+<text x="709" y="169" text-anchor="middle" font-family="Inter,Arial" font-size="16" font-weight="800" fill="#fff">stable operator path</text>
+<text x="709" y="194" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="13" fill="#bdbdbd">output</text>
+<rect x="95" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="170" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">release notes</text><rect x="275" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="350" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">plugin registry</text><rect x="455" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="530" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">telemetry</text><rect x="635" y="248" width="150" height="42" rx="12" fill="#111" stroke="#303030"/><text x="710" y="274" text-anchor="middle" font-size="14" fill="#f4f4f4">upgrade</text>
+<rect x="58" y="312" width="704" height="2" fill="#3B82F6" opacity=".65"/>
+<text x="410" y="335" text-anchor="middle" font-family="Inter,Arial" font-size="15" fill="#eeeeee">A healthy release cadence is not only features. It is update reliability, observability, and compatibility.</text>
+</svg>
+<figcaption style="margin-top:12px;color:var(--text);opacity:.82;font-size:.95rem">A simplified operating map for the post: where the user request enters, where the integration boundary sits, and what has to be true before the output is trusted.</figcaption>
+</figure>
 <div class="callout callout-info">
 <div class="callout-title">Evidence used</div>
 <p>This note is based on the public <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener">OpenClaw 2026.4.25 GitHub release</a>, the repository release index, and OpenClaw documentation for updating, getting started, model selection, and failover. I am not inferring hidden roadmap details from the tag.</p>
@@ -206,6 +232,9 @@ tr:last-child td{border-bottom:none}
 <div class="callout-title">My takeaway</div>
 <p>This release is worth writing about because it is specific. It shows OpenClaw paying down operational complexity: voice scope, plugin state, telemetry, browser readiness, setup repair, and updates. That is exactly the work an agent project has to do if it wants daily usage instead of one viral demo.</p>
 </div>
+<h2>How I would read the diagram</h2>
+<p>The April release is useful to read as a maintenance signal. A project with channels, plugins, and deployment modes cannot rely only on exciting features. It needs the boring pieces: update flow, registry persistence, telemetry coverage, browser reliability, and clear release notes.</p>
+<p>That is why I would judge this kind of release by operator confidence. Can someone upgrade without guessing? Can they see what changed? Can plugin authors understand compatibility? Can a broken browser action be debugged? Those questions matter as much as the headline feature list.</p>
 <h2>Sources</h2>
 <div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener"><div class="source-title">OpenClaw 2026.4.25 GitHub release</div><div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.4.25</div></a></div>
 <div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases" target="_blank" rel="noopener"><div class="source-title">OpenClaw release index</div><div class="source-url">https://github.com/openclaw/openclaw/releases</div></a></div>

--- a/docs/blog/v2026-4-25-release-cadence.html
+++ b/docs/blog/v2026-4-25-release-cadence.html
@@ -3,16 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode</title>
-<meta name="description" content="The April release train is the clearest recent signal: OpenClaw is now moving through daily tagged releases and a fast plugin ecosystem.">
-<meta property="og:title" content="OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode">
-<meta property="og:description" content="The April release train is the clearest recent signal: OpenClaw is now moving through daily tagged releases and a fast plugin ecosystem.">
+<title>OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle</title>
+<meta name="description" content="A researched read on OpenClaw v2026.4.25: TTS, cold plugin registry, OpenTelemetry, browser automation, install hardening, and what a fast release cadence means for operators.">
+<meta property="og:title" content="OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle">
+<meta property="og:description" content="A researched read on OpenClaw v2026.4.25: TTS, cold plugin registry, OpenTelemetry, browser automation, install hardening, and what a fast release cadence means for operators.">
 <meta property="og:image" content="https://openclawsearch.com/og-image.png">
 <meta property="og:url" content="https://openclawsearch.com/blog/v2026-4-25-release-cadence">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode">
-<meta name="twitter:description" content="The April release train is the clearest recent signal: OpenClaw is now moving through daily tagged releases and a fast plugin ecosystem.">
+<meta name="twitter:title" content="OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle">
+<meta name="twitter:description" content="A researched read on OpenClaw v2026.4.25: TTS, cold plugin registry, OpenTelemetry, browser automation, install hardening, and what a fast release cadence means for operators.">
 <meta name="twitter:image" content="https://openclawsearch.com/og-image.png">
 <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/pixel-lobster.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -133,240 +133,86 @@ tr:last-child td{border-bottom:none}
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Release</div>
-<h1 class="article-title">OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode</h1>
-<p class="article-subtitle">The April release train is the clearest recent signal: OpenClaw is now moving through daily tagged releases and a fast plugin ecosystem.</p>
+<h1 class="article-title">OpenClaw v2026.4.25 Is a Maintenance Release, Not a Hype Cycle</h1>
+<p class="article-subtitle">The April 25 release is useful because it shows the project moving from launch energy into operational detail: voice controls, plugin registry hardening, telemetry, browser reliability, and safer updates.</p>
 <div class="article-meta">
 <span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
 <span>Apr 27, 2026</span>
-<span>Long-form ecosystem analysis</span>
+<span>Release analysis</span>
 <span>Week of Apr 21, 2026</span>
 </div>
 <div class="article-pills">
-<span class="article-pill">Release</span>
 <span class="article-pill">v2026.4.25</span>
-<span class="article-pill">April 2026</span>
+<span class="article-pill">Release cadence</span>
+<span class="article-pill">Operations</span>
 </div>
 </header>
 <div class="callout callout-info">
-<div class="callout-title">Timeline note</div>
-<p>
-This post is part of the OpenClaw ecosystem timeline after the February blog window.
-I am placing it in Week of Apr 21, 2026 because the public source became visible or materially relevant around this period.
-</p>
-<p>
-The goal is not to mix February launch signals with March compatibility signals or April release cadence.
-Each post should stand on the public source for that week and explain why the signal matters to builders.
-</p>
+<div class="callout-title">Evidence used</div>
+<p>This note is based on the public <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener">OpenClaw 2026.4.25 GitHub release</a>, the repository release index, and OpenClaw documentation for updating, getting started, model selection, and failover. I am not inferring hidden roadmap details from the tag.</p>
 </div>
-<h2>The short version</h2>
-<p>
-The April release cadence says OpenClaw has moved from launch energy into maintenance reality.
-Daily tags are a signal that the project is alive, but they also create pressure on docs, plugins, and users.
-</p>
-<p>
-The public source I am using here is openclaw/openclaw.
-Your own personal AI assistant.
-Any OS.
-Any Platform.
-The lobster way.
-🦞
-</p>
-<p>
-I am not treating this as a random link to add to a directory.
-I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
-</p>
-<h2>Why I am writing about this</h2>
-<p>
-Open source ecosystems do not grow only through the main repository.
-They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
-</p>
-<p>
-That is why this kind of source matters.
-It shows what developers are trying to solve after the first install works.
-</p>
-<p>
-The first wave of attention usually asks whether the project is interesting.
-The second wave asks whether it can be used in a real workflow.
-These posts are about that second wave.
-</p>
-<h2>The wrong read</h2>
-<p>
-The wrong read is that more releases always means more progress.
-Release cadence is useful only when users can understand what changed and what might break.
-</p>
-<p>
-I want to avoid the easy hype version because it does not help anyone.
-If we just say every new plugin is a revolution, the blog becomes useless.
-The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
-</p>
-<p>
-A good ecosystem post should leave a reader with a sharper mental model, not just another link.
-</p>
-<h2>What the source actually shows</h2>
+<h2>The useful read</h2>
+<p>OpenClaw v2026.4.25 is not interesting because it has a dramatic feature name. It is interesting because it is full of maintenance work that only appears once a project is being used in real environments: text-to-speech controls, plugin startup paths, telemetry coverage, browser automation failure modes, setup repair, and cross-platform install hardening.</p>
+<p>That is what a fast agent project looks like after the first wave. The public repo can have hundreds of thousands of stars, but operators still care about smaller questions: Can I update without corrupting state? Can I see why a model call failed? Can plugin discovery be deterministic? Can browser automation survive a slower host?</p>
+<h2>What the release source shows</h2>
 <div class="table-wrap">
 <table>
-<thead>
-<tr><th>Field</th><th>Value</th></tr>
-</thead>
+<thead><tr><th>Field</th><th>Public release detail</th></tr></thead>
 <tbody>
-<tr><td>Source type</td><td>GitHub repository</td></tr>
-<tr><td>Repository</td><td>openclaw/openclaw</td></tr>
-<tr><td>Created</td><td>2025-11-24</td></tr>
-<tr><td>Last public update</td><td>2026-04-28</td></tr>
-<tr><td>Stars at review time</td><td>365603</td></tr>
-<tr><td>License</td><td>MIT</td></tr>
+<tr><td>Release</td><td>OpenClaw 2026.4.25</td></tr>
+<tr><td>Tag</td><td><code>v2026.4.25</code></td></tr>
+<tr><td>Published</td><td>Apr 27, 2026 on GitHub</td></tr>
+<tr><td>Commit</td><td><code>aa36ee6</code>, verified SSH signature shown by GitHub</td></tr>
+<tr><td>Release train context</td><td>Beta tags for 2026.4.25 preceded the stable release; 2026.4.26 followed shortly after</td></tr>
+<tr><td>Main areas</td><td>TTS, plugin registry, OpenTelemetry, browser automation, Control UI/setup, install/update hardening</td></tr>
 </tbody>
 </table>
 </div>
-<h2>The developer reality before this</h2>
-<p>
-Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
-That is the demo version.
-The real version is messier.
-</p>
-<p>
-Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
-</p>
-<p>
-This is why small ecosystem projects matter.
-Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
-</p>
-<h2>What changes for OpenClaw users</h2>
-<p>
-Builders should pin versions, read release notes, and test plugins against the runtime they actually deploy.
-</p>
-<p>
-The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
-</p>
-<p>
-If the answer is clear, the resource belongs in the ecosystem conversation.
-If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
-</p>
-<h2>What changes for maintainers</h2>
-<p>
-For maintainers, every external resource creates two jobs.
-First, describe the project accurately.
-Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
-</p>
-<p>
-That is why I prefer neutral directory language.
-Say what the tool connects, what workflow it supports, and where the source lives.
-Do not add fake maturity around it.
-</p>
-<p>
-The better the ecosystem gets, the more important this discipline becomes.
-A big awesome list can either help people navigate the space or become a pile of unchecked links.
-</p>
-<h2>The operational question</h2>
-<p>
-Operators need a simple rule: do not run critical agents on an untested moving target unless rollback is already solved.
-</p>
-<p>
-Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
-</p>
-<p>
-Every integration should be evaluated against those boring failures.
-If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
-</p>
-<h2>How I would evaluate it</h2>
-<p>
-I would start with the README and the smallest working example.
-If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
-</p>
-<p>
-Then I would test the failure path.
-What happens when the model returns a bad answer?
-What happens when an API call fails?
-What happens when the channel sends an unexpected payload?
-What happens when the user asks for something outside scope?
-</p>
-<p>
-Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
-That is the balance OpenClaw needs as the ecosystem grows.
-</p>
-<div class="checklist">
-<h3>Review checklist before adopting this pattern</h3>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the source public and inspectable?</span>
+<h2>Voice moved from demo to controls</h2>
+<p>The release notes put TTS first. That is appropriate: voice is where personal assistants quickly stop being a toy. The release adds or expands commands such as <code>/tts latest</code>, <code>/tts chat on|off|default</code>, <code>/tts audio</code>, <code>/tts status</code>, and <code>/tts persona</code>. It also documents per-agent and per-channel or per-account overrides.</p>
+<p>The important part is not simply “more providers.” The release mentions Azure Speech, Xiaomi, Local CLI, Inworld, Volcengine, and ElevenLabs v3 coverage, but the operational improvement is control scope. A user may want auto-TTS in one chat and silence in another. A team may want a specific provider for one agent and a local path for another. Global voice settings are too blunt for a multi-channel assistant.</p>
+<h2>The plugin registry change is a reliability signal</h2>
+<p>The release says plugin startup and install paths move to a <strong>cold persisted registry</strong>, reducing broad manifest scans and making plugin update, repair, provider discovery, and install metadata more deterministic. That is the kind of change most users will not notice when it works, but it matters for a project with many plugins and provider integrations.</p>
+<p>OpenClaw’s plugin ecosystem creates a boot-time problem: every startup cannot be an expensive rediscovery exercise. A persisted registry gives the runtime a stable snapshot to inspect, refresh, and repair. The release also points users to commands such as <code>openclaw plugins registry</code>, <code>openclaw plugins registry --refresh</code>, <code>openclaw plugins list</code>, and <code>openclaw doctor --fix</code>. That is maintenance UX, not launch-page UX.</p>
+<div class="callout callout-tip">
+<div class="callout-title">Why this matters</div>
+<p>Agent projects tend to fail through boring infrastructure: stale plugin metadata, half-installed dependencies, duplicated provider entries, or startup scans that become slow enough that users stop restarting. A deterministic registry is a direct response to those boring failures.</p>
 </div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does the README explain the real setup path?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Are required tokens, permissions, and scopes documented?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Can the integration fail safely?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Does it keep enough logs to debug a bad run?</span>
-</div>
-<div class="checklist-item">
-<span class="checklist-box"></span>
-<span>Is the date context clear so old guidance is not treated as current?</span>
-</div>
-</div>
+<h2>Telemetry became more specific</h2>
+<p>v2026.4.25 expands OpenTelemetry coverage across model calls, token usage, tool loops, harness runs, exec processes, outbound delivery, context assembly, and memory pressure. The release also calls out bounded low-cardinality attributes. That detail matters: telemetry that explodes cardinality is expensive and often unusable.</p>
+<p>The release names signals such as <code>openclaw.harness.run</code>, <code>openclaw.harness.duration_ms</code>, <code>openclaw.context.assembled</code>, <code>openclaw.tool.loop</code>, <code>openclaw.exec</code>, <code>gen_ai.client.token.usage</code>, and <code>gen_ai.client.operation.duration</code>. For operators, those names are the difference between “the bot felt slow” and “context assembly grew, model latency increased, then a tool loop retried.”</p>
+<h2>Browser automation got safer in the details</h2>
+<p>The release notes mention safer tab URLs, iframe-aware role snapshots, CDP readiness tuning, headless one-shot launch, and deeper browser doctor probes for slow hosts. Those are not glamorous changes, but browser automation is one of the fastest ways for an agent to surprise users. It touches identity, sessions, live web pages, and sometimes payment or admin screens.</p>
+<p>The new <code>openclaw browser start --headless</code> flag is described as a one-shot managed browser launch override, not a persisted config rewrite. That distinction is good design. Operators often need a temporary diagnostic path without accidentally changing the long-running browser configuration.</p>
+<h2>Install and update hardening is the real release-cadence story</h2>
+<p>The OpenClaw updating docs describe <code>openclaw update</code> as the recommended path. It detects npm or git installs, fetches a target version, runs <code>openclaw doctor</code>, and restarts the gateway. The docs also describe stable, beta, and dev channels, dry runs, and switching between npm and git installs while keeping user state in <code>~/.openclaw</code>.</p>
+<p>That context explains why the v2026.4.25 hardening work matters. The release mentions Windows, macOS, Linux, Docker, bundled plugin runtime dependencies, Node service restarts, LaunchAgent token rotation, and mixed-version gateway verification. A project can only ship daily or near-daily releases if the update path is boring. Otherwise cadence becomes churn.</p>
+<h2>What users should do with this release</h2>
+<p>If you run OpenClaw casually, the practical advice is simple: use the documented updater, read the release notes, and run <code>openclaw doctor</code> after updates. If you run it as part of a workflow, treat v2026.4.25 as a reason to tighten your own release process.</p>
+<ul>
+<li><strong>Pin what matters.</strong> Know which OpenClaw version, plugin versions, provider settings, and Node runtime your workflow depends on.</li>
+<li><strong>Use dry runs where possible.</strong> The update docs expose <code>--dry-run</code> for channel switches and previews.</li>
+<li><strong>Check plugin registry state.</strong> Use the new registry inspection and refresh commands when startup behavior changes.</li>
+<li><strong>Watch telemetry after update.</strong> Compare model latency, token usage, context assembly, tool loops, and exec spans before and after.</li>
+<li><strong>Test browser automation separately.</strong> Browser changes deserve dedicated checks because failures may be stateful and host-specific.</li>
+</ul>
+<h2>What maintainers should take from it</h2>
+<p>The release is a reminder that the ecosystem now needs compatibility language. Daily tags can be a strength, but only if users can understand which releases are stable, which are beta, and what changed across the train. The release index shows 2026.4.25 beta tags, then stable 2026.4.25, then 2026.4.26 soon after. That cadence is fine if changelogs remain specific and upgrade paths remain testable.</p>
+<p>For a directory or blog, the right coverage is not “OpenClaw ships fast.” The right coverage is: <strong>fast releases are now carrying operational work</strong>. TTS settings, plugin registries, telemetry, browser diagnostics, and updater safety are the features that make a personal assistant survivable after the first install.</p>
 <h2>What I would not claim</h2>
-<p>
-I would not claim this is the best solution in its category unless there is evidence.
-I would not claim production readiness unless the project documents production behavior.
-I would not claim broad adoption from a single repo, package, or release note.
-</p>
-<p>
-The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
-</p>
-<p>
-That kind of claim is enough.
-It respects the source and gives readers a reason to inspect it themselves.
-</p>
-<h2>Why this matters for the OpenClaw ecosystem</h2>
-<p>
-OpenClaw is not only a repository.
-It is becoming a set of operating patterns around agents.
-Some patterns will survive.
-Some will disappear.
-The job of this blog is to notice the useful ones early without turning every link into hype.
-</p>
-<p>
-This source matters because it points to one of those patterns.
-It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
-</p>
-<p>
-The next maturity layer is changelog discipline, compatibility testing, and stable channels.
-</p>
-<h2>The practical read</h2>
-<p>
-If you are building on OpenClaw, do not copy the ecosystem blindly.
-Use it as a map of problems other builders are already hitting.
-</p>
-<p>
-When you see a channel plugin, ask what communication surface your users already live in.
-When you see a deployment module, ask what day-two operations are missing.
-When you see a memory plugin, ask what should be remembered and what should be forgotten.
-When you see observability, ask what you would need to debug a production incident.
-</p>
-<p>
-That is the mindset that turns an awesome list into useful infrastructure research.
-</p>
+<p>I would not claim v2026.4.25 is a stability guarantee. I would not claim every plugin is now safe because registry handling improved. I would not claim voice is production-ready for every provider or channel. The release notes show meaningful work, not universal maturity.</p>
+<p>The bounded claim is stronger: v2026.4.25 is a concrete snapshot of OpenClaw entering release-cadence mode, where much of the engineering value is in repair paths, diagnostics, and predictable runtime behavior.</p>
 <div class="callout callout-solution">
 <div class="callout-title">My takeaway</div>
-<p>
-OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode is worth tracking because it makes one OpenClaw operating pattern more concrete.
-The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
-</p>
+<p>This release is worth writing about because it is specific. It shows OpenClaw paying down operational complexity: voice scope, plugin state, telemetry, browser readiness, setup repair, and updates. That is exactly the work an agent project has to do if it wants daily usage instead of one viral demo.</p>
 </div>
-<h2>Source</h2>
-<div class="source-ref">
-<a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener">
-<div class="source-title">openclaw/openclaw</div>
-<div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.4.25</div>
-</a>
-</div>
+<h2>Sources</h2>
+<div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener"><div class="source-title">OpenClaw 2026.4.25 GitHub release</div><div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.4.25</div></a></div>
+<div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases" target="_blank" rel="noopener"><div class="source-title">OpenClaw release index</div><div class="source-url">https://github.com/openclaw/openclaw/releases</div></a></div>
+<div class="source-ref"><a href="https://docs.openclaw.ai/install/updating" target="_blank" rel="noopener"><div class="source-title">OpenClaw updating documentation</div><div class="source-url">https://docs.openclaw.ai/install/updating</div></a></div>
+<div class="source-ref"><a href="https://docs.openclaw.ai/start/getting-started" target="_blank" rel="noopener"><div class="source-title">OpenClaw getting started documentation</div><div class="source-url">https://docs.openclaw.ai/start/getting-started</div></a></div>
+<div class="source-ref"><a href="https://docs.openclaw.ai/concepts/models" target="_blank" rel="noopener"><div class="source-title">OpenClaw models documentation</div><div class="source-url">https://docs.openclaw.ai/concepts/models</div></a></div>
+<div class="source-ref"><a href="https://docs.openclaw.ai/concepts/model-failover" target="_blank" rel="noopener"><div class="source-title">OpenClaw model failover documentation</div><div class="source-url">https://docs.openclaw.ai/concepts/model-failover</div></a></div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
 <script>
@@ -386,119 +232,6 @@ localStorage.setItem("theme",theme);
 }
 const saved=localStorage.getItem("theme");
 if(saved){setTheme(saved);}
-<h2>Additional builder notes</h2>
-<h3>Adoption</h3>
-<p>
-A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
-</p>
-<h3>Distribution</h3>
-<p>
-The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
-</p>
-<h3>Trust</h3>
-<p>
-Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
-</p>
-<h3>Maintenance</h3>
-<p>
-Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
-</p>
-<h3>Scope</h3>
-<p>
-The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
-</p>
-<h3>Documentation</h3>
-<p>
-Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
-</p>
-<h3>Ecosystem fit</h3>
-<p>
-The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
-</p>
-<h3>Review habit</h3>
-<p>
-Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
-</p>
-<h3>User value</h3>
-<p>
-The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
-</p>
-<h3>Operating model</h3>
-<p>
-The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
-</p>
-<h3>Quality bar</h3>
-<p>
-The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
-</p>
-<h3>Next step</h3>
-<p>
-The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
-</p>
-<h3>Reader promise</h3>
-<p>
-The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
-</p>
-<h3>Directory discipline</h3>
-<p>
-A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
-</p>
-<h3>Date context</h3>
-<p>
-Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
-</p>
-<h3>Evidence</h3>
-<p>
-Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
-</p>
-<h3>Hype control</h3>
-<p>
-The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
-</p>
-<h3>Developer empathy</h3>
-<p>
-Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
-</p>
-<h3>Operational empathy</h3>
-<p>
-Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
-</p>
-<h3>Ecosystem memory</h3>
-<p>
-These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
-</p>
-<h3>Practical filter</h3>
-<p>
-The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
-</p>
-<h3>Future research</h3>
-<p>
-The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
-</p>
-<h3>Writing standard</h3>
-<p>
-The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
-</p>
-<h3>Reader action</h3>
-<p>
-A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
-</p>
-<h3>Public copy</h3>
-<p>
-Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
-</p>
-<h3>Maintainer habit</h3>
-<p>
-For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
-</p>
-<h3>Builder takeaway</h3>
-<p>
-For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
-</p>
-<h3>Long-term value</h3>
-<p>
-The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
-</p>
 button.addEventListener("click",function(){
 setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
 });

--- a/docs/blog/v2026-4-25-release-cadence.html
+++ b/docs/blog/v2026-4-25-release-cadence.html
@@ -20,44 +20,489 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0A0A0A;--bg-s1:#111;--bg-s2:#1A1A1A;--text:#EDEDED;--text-muted:#888;--card:rgba(255,255,255,.05);--card-border:rgba(255,255,255,.08);--primary:#DC2626;--primary-light:#EF4444;--link:#EF4444;--link-hover:#DC2626;--badge-bg:rgba(220,38,38,.12);--badge-text:#EF4444;--nav-bg:rgba(10,10,10,.8);--green:#22C55E;--green-bg:rgba(34,197,94,.08);--green-border:rgba(34,197,94,.25);--blue-bg:rgba(59,130,246,.08);--blue-border:rgba(59,130,246,.25)}
-[data-theme="light"]{--bg:#FAFAFA;--bg-s1:#FFF;--bg-s2:#F5F5F5;--text:#171717;--text-muted:#666;--card:#FFF;--card-border:rgba(0,0,0,.08);--link:#DC2626;--link-hover:#B91C1C;--badge-bg:rgba(220,38,38,.08);--badge-text:#DC2626;--nav-bg:rgba(250,250,250,.85);--green-bg:rgba(34,197,94,.06);--green-border:rgba(34,197,94,.2);--blue-bg:rgba(59,130,246,.06);--blue-border:rgba(59,130,246,.2)}
-html{scroll-behavior:smooth;scroll-padding-top:80px}body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none}.nav-logo .claw{color:var(--primary)}.nav-actions{display:flex;align-items:center;gap:12px}.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border)}.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px}.article{max-width:820px;margin:0 auto;padding:0 24px 80px}.article-header{padding:72px 0 42px;border-bottom:1px solid var(--card-border);margin-bottom:42px}.article-badge{display:inline-flex;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-.03em;line-height:1.15;margin-bottom:16px}.article-title .hl{color:var(--primary)}.article-subtitle{font-size:1.15rem;color:var(--text-muted);margin-bottom:24px}.article-meta{display:flex;flex-wrap:wrap;gap:16px;color:var(--text-muted);font-size:.85rem}.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}.article h2{font-size:1.55rem;font-weight:800;margin:48px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}.article h3{font-size:1.15rem;font-weight:700;margin:30px 0 12px}.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.8}.article strong{color:var(--text);font-weight:650}.article a{color:var(--link);text-decoration:none}.article a:hover{color:var(--link-hover);text-decoration:underline}.article ul{margin:0 0 22px 24px;color:var(--text-muted)}.article li{margin-bottom:8px}.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}.callout-title{font-weight:800;font-size:.9rem;margin-bottom:8px;color:var(--text)}.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}.callout-solution{border-color:var(--green-border);background:var(--green-bg)}.source-ref{margin:18px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}.source-title{font-weight:700;color:var(--text);margin-bottom:2px}.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}.footer a{color:var(--link);text-decoration:none}@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link{padding:4px 8px;font-size:.75rem}.gh-link span{display:none}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article h2{font-size:1.3rem}}
+:root{
+  --bg:#0A0A0A;
+  --bg-s1:#111111;
+  --bg-s2:#1A1A1A;
+  --text:#EDEDED;
+  --text-muted:#888888;
+  --card:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.08);
+  --primary:#DC2626;
+  --primary-light:#EF4444;
+  --link:#EF4444;
+  --link-hover:#DC2626;
+  --badge-bg:rgba(220,38,38,0.12);
+  --badge-text:#EF4444;
+  --green:#22C55E;
+  --green-bg:rgba(34,197,94,0.08);
+  --green-border:rgba(34,197,94,0.25);
+  --yellow:#F59E0B;
+  --yellow-bg:rgba(245,158,11,0.08);
+  --yellow-border:rgba(245,158,11,0.25);
+  --blue:#3B82F6;
+  --blue-bg:rgba(59,130,246,0.08);
+  --blue-border:rgba(59,130,246,0.25);
+  --nav-bg:rgba(10,10,10,0.8);
+}
+[data-theme="light"]{
+  --bg:#FAFAFA;
+  --bg-s1:#FFFFFF;
+  --bg-s2:#F5F5F5;
+  --text:#171717;
+  --text-muted:#666666;
+  --card:#FFFFFF;
+  --card-border:rgba(0,0,0,0.08);
+  --link:#DC2626;
+  --link-hover:#B91C1C;
+  --badge-bg:rgba(220,38,38,0.08);
+  --badge-text:#DC2626;
+  --nav-bg:rgba(250,250,250,0.85);
+  --green-bg:rgba(34,197,94,0.06);
+  --green-border:rgba(34,197,94,0.2);
+  --yellow-bg:rgba(245,158,11,0.06);
+  --yellow-border:rgba(245,158,11,0.2);
+  --blue-bg:rgba(59,130,246,0.06);
+  --blue-border:rgba(59,130,246,0.2);
+}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.75;font-size:16px;transition:background .3s,color .3s}
+.nav{position:sticky;top:0;z-index:100;background:var(--nav-bg);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--card-border)}
+.nav-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:64px}
+.nav-logo{font-weight:800;font-size:1.1rem;color:var(--text);text-decoration:none;display:flex;align-items:center;gap:8px}
+.nav-logo .claw{color:var(--primary)}
+.nav-actions{display:flex;align-items:center;gap:12px}
+.nav-link,.gh-link{color:var(--text-muted);text-decoration:none;font-size:.85rem;font-weight:500;padding:6px 14px;border-radius:8px;border:1px solid var(--card-border);transition:all .2s}
+.nav-link:hover,.nav-link.active,.gh-link:hover{color:var(--text);border-color:var(--primary)}
+.theme-toggle{background:var(--card);border:1px solid var(--card-border);color:var(--text);cursor:pointer;width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
+.article{max-width:820px;margin:0 auto;padding:0 24px 80px}
+.article-header{padding:80px 0 48px;border-bottom:1px solid var(--card-border);margin-bottom:48px}
+.article-badge{display:inline-flex;align-items:center;gap:6px;background:var(--badge-bg);color:var(--badge-text);font-size:.8rem;font-weight:700;padding:4px 14px;border-radius:16px;margin-bottom:20px}
+.article-title{font-size:clamp(2rem,5vw,3rem);font-weight:900;letter-spacing:-0.03em;line-height:1.15;margin-bottom:16px}
+.article-title .hl{color:var(--primary)}
+.article-subtitle{font-size:1.2rem;color:var(--text-muted);margin-bottom:24px;line-height:1.5}
+.article-meta{display:flex;flex-wrap:wrap;align-items:center;gap:16px;color:var(--text-muted);font-size:.85rem}
+.article-pills{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.article-pill{font-size:.75rem;padding:4px 12px;border-radius:6px;background:var(--card);border:1px solid var(--card-border);color:var(--text-muted);font-weight:500}
+.article h2{font-size:1.55rem;font-weight:800;letter-spacing:-0.02em;margin:52px 0 18px;padding-left:16px;border-left:4px solid var(--primary);line-height:1.3}
+.article h3{font-size:1.18rem;font-weight:750;margin:34px 0 12px;color:var(--text)}
+.article p{color:var(--text-muted);margin-bottom:18px;line-height:1.85}
+.article strong{color:var(--text);font-weight:650}
+.article a{color:var(--link);text-decoration:none;transition:color .2s}
+.article a:hover{color:var(--link-hover);text-decoration:underline}
+.article ul,.article ol{margin:0 0 22px 24px;color:var(--text-muted)}
+.article li{margin-bottom:8px;line-height:1.75}
+.article li strong{color:var(--text)}
+.article code{font-family:'JetBrains Mono',monospace;font-size:.85em;background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;color:var(--primary-light)}
+.callout{margin:24px 0;padding:20px 24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.callout-title{font-weight:750;font-size:.9rem;margin-bottom:8px;color:var(--text);display:flex;align-items:center;gap:8px}
+.callout-info{border-color:var(--blue-border);background:var(--blue-bg)}
+.callout-solution{border-color:var(--green-border);background:var(--green-bg)}
+.callout-tip{border-color:var(--yellow-border);background:var(--yellow-bg)}
+.source-ref{margin:16px 0;padding:16px 18px;border-radius:10px;border:1px solid var(--card-border);background:var(--bg-s1);font-size:.9rem;color:var(--text-muted)}
+.source-title{font-weight:700;color:var(--text);margin-bottom:4px}
+.source-url{font-size:.8rem;color:var(--text-muted);word-break:break-all}
+.table-wrap{overflow-x:auto;margin:20px 0 28px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th{text-align:left;padding:12px 16px;font-weight:650;color:var(--text);border-bottom:1px solid var(--card-border)}
+td{padding:10px 16px;border-bottom:1px solid var(--card-border);color:var(--text-muted)}
+tr:last-child td{border-bottom:none}
+.checklist{margin:24px 0;padding:24px;border-radius:12px;border:1px solid var(--card-border);background:var(--bg-s1)}
+.checklist h3{margin:0 0 16px;font-size:1rem}
+.checklist-item{display:flex;align-items:flex-start;gap:10px;padding:6px 0;font-size:.9rem;color:var(--text-muted)}
+.checklist-box{width:18px;height:18px;border:2px solid var(--card-border);border-radius:4px;flex-shrink:0;margin-top:2px}
+.footer{text-align:center;padding:48px 24px;border-top:1px solid var(--card-border);color:var(--text-muted);font-size:.85rem}
+.footer a{color:var(--link);text-decoration:none}
+@media(max-width:768px){.nav-inner{padding:0 10px}.nav-actions{gap:6px}.nav-link,.gh-link{padding:4px 8px;font-size:.75rem}.article{padding:0 16px 40px}.article-header{padding:48px 0 32px}.article-title{font-size:1.8rem}.article-subtitle{font-size:1rem}.article h2{font-size:1.3rem}}
 </style>
 </head>
 <body>
-<nav class="nav"><div class="nav-inner">
+<nav class="nav">
+<div class="nav-inner">
 <a href="/" class="nav-logo"><span class="claw">Open</span>Claw</a>
-<div class="nav-actions"><a href="/" class="nav-link">Home</a><a href="/directory" class="nav-link">Directory</a><a href="/use-cases" class="nav-link">Use Cases</a><a href="/blog" class="nav-link active">Blog</a><button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button><a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a></div>
-</div></nav>
+<div class="nav-actions">
+<a href="/" class="nav-link">Home</a>
+<a href="/directory" class="nav-link">Directory</a>
+<a href="/use-cases" class="nav-link">Use Cases</a>
+<a href="/blog" class="nav-link active">Blog</a>
+<button class="theme-toggle" id="themeToggle" title="Toggle theme"><span id="themeIcon">☾</span></button>
+<a href="https://github.com/rohitg00/awesome-openclaw" target="_blank" rel="noopener" class="gh-link"><span>GitHub</span></a>
+</div>
+</div>
+</nav>
 <article class="article">
 <header class="article-header">
 <div class="article-badge">Release</div>
 <h1 class="article-title">OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode</h1>
 <p class="article-subtitle">The April release train is the clearest recent signal: OpenClaw is now moving through daily tagged releases and a fast plugin ecosystem.</p>
-<div class="article-meta"><span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span><span>Apr 27, 2026</span><span>9 min read</span><span>Week of Apr 21, 2026</span></div>
-<div class="article-pills"><span class="article-pill">Release</span>
+<div class="article-meta">
+<span>Rohit Ghumare · <a href="https://x.com/ghumare64" target="_blank" rel="noopener">@ghumare64</a></span>
+<span>Apr 27, 2026</span>
+<span>Long-form ecosystem analysis</span>
+<span>Week of Apr 21, 2026</span>
+</div>
+<div class="article-pills">
+<span class="article-pill">Release</span>
 <span class="article-pill">v2026.4.25</span>
-<span class="article-pill">April 2026</span></div>
+<span class="article-pill">April 2026</span>
+</div>
 </header>
-<div class="callout callout-info"><div class="callout-title">Timeline note</div><p>v2026.4.20 published Apr 21, v2026.4.25 published Apr 27, 2026.</p><p>This article is placed in the week where the public source became relevant in the OpenClaw ecosystem. Dates are kept explicit so February, March, and April signals do not get mixed together.</p></div>
-<p><strong>OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode</strong></p>
-<p>OpenClaw&#x27;s release list shows a dense late-April cadence: v2026.4.20 on Apr 21, v2026.4.21 on Apr 22, v2026.4.22 on Apr 23, v2026.4.23 on Apr 24, v2026.4.24 on Apr 25, and v2026.4.25 on Apr 27.</p>
-<h2>What actually changed</h2>
-<p>That cadence changes how the ecosystem should document things. A static guide can become stale in days. Directory entries, use cases, and tutorials need dates, version notes, and clear source links.</p>
-<p>The bigger pattern is that OpenClaw is no longer only a personal assistant repo. It is becoming a small operating layer around channels, tools, memory, automation, observability, and deployment. Each new project is another proof point, but the dates matter. A February voice project is not the same signal as an April release train.</p>
-<h2>Why developers should care</h2>
-<p>Developers do not adopt platforms because the category sounds exciting. They adopt them when a specific workflow becomes easier: message an agent, run a tool, inspect the output, recover from failure, and keep control over the system.</p>
-<p>This finding matters because it makes one part of that workflow more concrete. It either improves a channel, a deployment path, a debugging loop, a memory layer, or a team coordination pattern.</p>
+<div class="callout callout-info">
+<div class="callout-title">Timeline note</div>
+<p>
+This post is part of the OpenClaw ecosystem timeline after the February blog window.
+I am placing it in Week of Apr 21, 2026 because the public source became visible or materially relevant around this period.
+</p>
+<p>
+The goal is not to mix February launch signals with March compatibility signals or April release cadence.
+Each post should stand on the public source for that week and explain why the signal matters to builders.
+</p>
+</div>
+<h2>The short version</h2>
+<p>
+The April release cadence says OpenClaw has moved from launch energy into maintenance reality.
+Daily tags are a signal that the project is alive, but they also create pressure on docs, plugins, and users.
+</p>
+<p>
+The public source I am using here is openclaw/openclaw.
+Your own personal AI assistant.
+Any OS.
+Any Platform.
+The lobster way.
+🦞
+</p>
+<p>
+I am not treating this as a random link to add to a directory.
+I am treating it as a small ecosystem signal: a sign of where users are trying to take OpenClaw in practice.
+</p>
+<h2>Why I am writing about this</h2>
+<p>
+Open source ecosystems do not grow only through the main repository.
+They grow when people build deployment paths, channel adapters, memory layers, observability hooks, team workflows, and small utilities around the core project.
+</p>
+<p>
+That is why this kind of source matters.
+It shows what developers are trying to solve after the first install works.
+</p>
+<p>
+The first wave of attention usually asks whether the project is interesting.
+The second wave asks whether it can be used in a real workflow.
+These posts are about that second wave.
+</p>
+<h2>The wrong read</h2>
+<p>
+The wrong read is that more releases always means more progress.
+Release cadence is useful only when users can understand what changed and what might break.
+</p>
+<p>
+I want to avoid the easy hype version because it does not help anyone.
+If we just say every new plugin is a revolution, the blog becomes useless.
+The value is in explaining what changed, what did not change, and what a developer should inspect before depending on it.
+</p>
+<p>
+A good ecosystem post should leave a reader with a sharper mental model, not just another link.
+</p>
+<h2>What the source actually shows</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr><th>Field</th><th>Value</th></tr>
+</thead>
+<tbody>
+<tr><td>Source type</td><td>GitHub repository</td></tr>
+<tr><td>Repository</td><td>openclaw/openclaw</td></tr>
+<tr><td>Created</td><td>2025-11-24</td></tr>
+<tr><td>Last public update</td><td>2026-04-28</td></tr>
+<tr><td>Stars at review time</td><td>365603</td></tr>
+<tr><td>License</td><td>MIT</td></tr>
+</tbody>
+</table>
+</div>
+<h2>The developer reality before this</h2>
+<p>
+Most agent projects look simple from the outside: connect a model, connect a tool, send a message, get a response.
+That is the demo version.
+The real version is messier.
+</p>
+<p>
+Developers need repeatable setup, clear runtime boundaries, channel integration, logs, retries, permissions, memory, and ways to explain what happened when the agent is wrong.
+</p>
+<p>
+This is why small ecosystem projects matter.
+Each one is usually trying to remove one operational papercut that the core product cannot solve for every environment.
+</p>
+<h2>What changes for OpenClaw users</h2>
+<p>
+Builders should pin versions, read release notes, and test plugins against the runtime they actually deploy.
+</p>
+<p>
+The practical user question is not “should everyone install this?” The better question is “what job does this make clearer?”
+</p>
+<p>
+If the answer is clear, the resource belongs in the ecosystem conversation.
+If the answer is vague, it should stay out of any serious recommendation list until the use case becomes inspectable.
+</p>
+<h2>What changes for maintainers</h2>
+<p>
+For maintainers, every external resource creates two jobs.
+First, describe the project accurately.
+Second, avoid implying that it is officially endorsed, production-ready, or safe for every user unless the source actually proves that.
+</p>
+<p>
+That is why I prefer neutral directory language.
+Say what the tool connects, what workflow it supports, and where the source lives.
+Do not add fake maturity around it.
+</p>
+<p>
+The better the ecosystem gets, the more important this discipline becomes.
+A big awesome list can either help people navigate the space or become a pile of unchecked links.
+</p>
+<h2>The operational question</h2>
+<p>
+Operators need a simple rule: do not run critical agents on an untested moving target unless rollback is already solved.
+</p>
+<p>
+Agent systems fail in boring ways: expired keys, unclear permissions, old context, broken webhooks, silent retries, missing logs, and users not knowing what the bot just did.
+</p>
+<p>
+Every integration should be evaluated against those boring failures.
+If it only works in a happy-path screenshot, it is not ready to be treated as infrastructure.
+</p>
+<h2>How I would evaluate it</h2>
+<p>
+I would start with the README and the smallest working example.
+If the resource cannot explain its install path, environment variables, runtime assumptions, and expected output, I would not put it in front of new users yet.
+</p>
+<p>
+Then I would test the failure path.
+What happens when the model returns a bad answer?
+What happens when an API call fails?
+What happens when the channel sends an unexpected payload?
+What happens when the user asks for something outside scope?
+</p>
+<p>
+Finally, I would check whether the project makes a workflow easier without hiding the dangerous parts.
+That is the balance OpenClaw needs as the ecosystem grows.
+</p>
+<div class="checklist">
+<h3>Review checklist before adopting this pattern</h3>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the source public and inspectable?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does the README explain the real setup path?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Are required tokens, permissions, and scopes documented?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Can the integration fail safely?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Does it keep enough logs to debug a bad run?</span>
+</div>
+<div class="checklist-item">
+<span class="checklist-box"></span>
+<span>Is the date context clear so old guidance is not treated as current?</span>
+</div>
+</div>
+<h2>What I would not claim</h2>
+<p>
+I would not claim this is the best solution in its category unless there is evidence.
+I would not claim production readiness unless the project documents production behavior.
+I would not claim broad adoption from a single repo, package, or release note.
+</p>
+<p>
+The honest claim is narrower and more useful: this is a visible public signal that developers are pushing OpenClaw into a specific workflow area.
+</p>
+<p>
+That kind of claim is enough.
+It respects the source and gives readers a reason to inspect it themselves.
+</p>
+<h2>Why this matters for the OpenClaw ecosystem</h2>
+<p>
+OpenClaw is not only a repository.
+It is becoming a set of operating patterns around agents.
+Some patterns will survive.
+Some will disappear.
+The job of this blog is to notice the useful ones early without turning every link into hype.
+</p>
+<p>
+This source matters because it points to one of those patterns.
+It shows where developers are asking for more structure around agents: channels, memory, deployment, teams, traces, training, or governance.
+</p>
+<p>
+The next maturity layer is changelog discipline, compatibility testing, and stable channels.
+</p>
 <h2>The practical read</h2>
-<p>When writing about OpenClaw now, attach the date. Separate created date, updated date, and release date. Do not mix February ecosystem stories with April release behavior.</p>
-<div class="callout callout-solution"><div class="callout-title">What to add to the directory</div><p>Add the public resource, keep the description neutral, include the date context, and avoid unsupported claims. If the project is a plugin, say what surface it connects. If it is infrastructure, say what it deploys. If it is memory or observability, say what gets stored or traced.</p></div>
+<p>
+If you are building on OpenClaw, do not copy the ecosystem blindly.
+Use it as a map of problems other builders are already hitting.
+</p>
+<p>
+When you see a channel plugin, ask what communication surface your users already live in.
+When you see a deployment module, ask what day-two operations are missing.
+When you see a memory plugin, ask what should be remembered and what should be forgotten.
+When you see observability, ask what you would need to debug a production incident.
+</p>
+<p>
+That is the mindset that turns an awesome list into useful infrastructure research.
+</p>
+<div class="callout callout-solution">
+<div class="callout-title">My takeaway</div>
+<p>
+OpenClaw v2026.4.25 Shows the Project Has Entered Release-Cadence Mode is worth tracking because it makes one OpenClaw operating pattern more concrete.
+The right move is to document it carefully, keep the claims neutral, and connect it to the workflow problem it actually solves.
+</p>
+</div>
 <h2>Source</h2>
-<div class="source-ref"><a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener"><div class="source-title">OpenClaw v2026.4.25</div><div>https://github.com/openclaw/openclaw/releases/tag/v2026.4.25</div></a></div>
+<div class="source-ref">
+<a href="https://github.com/openclaw/openclaw/releases/tag/v2026.4.25" target="_blank" rel="noopener">
+<div class="source-title">openclaw/openclaw</div>
+<div class="source-url">https://github.com/openclaw/openclaw/releases/tag/v2026.4.25</div>
+</a>
+</div>
 </article>
 <footer class="footer"><p>Part of <a href="/">Awesome OpenClaw</a>. See the <a href="/directory">directory</a> and <a href="/use-cases">use cases</a>.</p></footer>
-
-<script>(function(){const $=s=>document.querySelector(s);const html=document.documentElement;function setTheme(t){if(t==='light'){html.setAttribute('data-theme','light');$('#themeIcon').textContent='☀'}else{html.removeAttribute('data-theme');$('#themeIcon').textContent='☾'}localStorage.setItem('theme',t)}const saved=localStorage.getItem('theme');if(saved)setTheme(saved);$('#themeToggle').addEventListener('click',()=>setTheme(html.getAttribute('data-theme')==='light'?'dark':'light'));})();</script>
-
+<script>
+(function(){
+const button=document.getElementById("themeToggle");
+const icon=document.getElementById("themeIcon");
+const html=document.documentElement;
+function setTheme(theme){
+if(theme==="light"){
+html.setAttribute("data-theme","light");
+icon.textContent="☀";
+}else{
+html.removeAttribute("data-theme");
+icon.textContent="☾";
+}
+localStorage.setItem("theme",theme);
+}
+const saved=localStorage.getItem("theme");
+if(saved){setTheme(saved);}
+<h2>Additional builder notes</h2>
+<h3>Adoption</h3>
+<p>
+A developer does not adopt an agent workflow because it sounds futuristic. They adopt it when it removes one repeated manual step without hiding the cost of that automation.
+</p>
+<h3>Distribution</h3>
+<p>
+The OpenClaw ecosystem is interesting because distribution keeps showing up as a technical problem. Channels, dashboards, hosting, and memory are all ways of getting the agent closer to the work.
+</p>
+<h3>Trust</h3>
+<p>
+Trust does not come from a better landing page. It comes from visible state, clear permissions, logs, examples, and a failure mode that a human can understand.
+</p>
+<h3>Maintenance</h3>
+<p>
+Every integration should be judged by how it behaves after the first successful demo. Does it survive updates? Does it explain errors? Does it document the assumptions?
+</p>
+<h3>Scope</h3>
+<p>
+The safest OpenClaw resources have a narrow job. They do one thing clearly, then let the user decide whether that thing belongs in a larger workflow.
+</p>
+<h3>Documentation</h3>
+<p>
+Good documentation should make the integration boring. The user should know what to install, what token to create, what command to run, and what output to expect.
+</p>
+<h3>Ecosystem fit</h3>
+<p>
+The resource is most useful when it connects to a repeated pattern in the ecosystem, not when it tries to look important by itself.
+</p>
+<h3>Review habit</h3>
+<p>
+Before adding a resource to a public directory, I want to know the source, the date, the workflow, the risk, and the reason a builder would care.
+</p>
+<h3>User value</h3>
+<p>
+The user value should be simple enough to explain in one sentence. If it takes five paragraphs to explain why the resource matters, the category may not be clear yet.
+</p>
+<h3>Operating model</h3>
+<p>
+The best OpenClaw additions point toward an operating model: request, route, execute, observe, recover, and document the result.
+</p>
+<h3>Quality bar</h3>
+<p>
+The quality bar is not whether the idea is exciting. The quality bar is whether a real user can inspect it, run it, and understand what changed.
+</p>
+<h3>Next step</h3>
+<p>
+The next step is not to hype the link. The next step is to place it carefully in the ecosystem map and keep the description honest.
+</p>
+<h3>Reader promise</h3>
+<p>
+The reader should leave with a practical interpretation, not only a summary. That is why the article keeps coming back to workflow, risk, and operating model.
+</p>
+<h3>Directory discipline</h3>
+<p>
+A directory entry should be shorter than a blog post, but the thinking behind it should be this careful. The public page should only keep the distilled version.
+</p>
+<h3>Date context</h3>
+<p>
+Date context matters because agent ecosystems move quickly. A February package, a March compatibility issue, and an April release train tell different stories.
+</p>
+<h3>Evidence</h3>
+<p>
+Evidence does not have to be dramatic. A repository, package, release note, or public example can be enough when the claim is appropriately narrow.
+</p>
+<h3>Hype control</h3>
+<p>
+The easiest way to make the blog weaker is to overclaim. The better habit is to make smaller claims with stronger evidence.
+</p>
+<h3>Developer empathy</h3>
+<p>
+Most developers are not looking for a category thesis. They are asking whether this saves time, reduces risk, or makes a workflow easier to operate.
+</p>
+<h3>Operational empathy</h3>
+<p>
+Operators care about what happens at 2 a.m. when a webhook fails, an API key expires, or a model starts returning bad output.
+</p>
+<h3>Ecosystem memory</h3>
+<p>
+These posts also create memory for the ecosystem. Later readers can see which signals appeared in which week and how the project expanded.
+</p>
+<h3>Practical filter</h3>
+<p>
+The practical filter is simple: if I cannot explain what the resource does, who it helps, and what to check before use, it does not deserve a strong recommendation.
+</p>
+<h3>Future research</h3>
+<p>
+The next round of research should compare these resources against real usage, not just existence. Stars and package dates are useful signals, but they are not the same as production adoption.
+</p>
+<h3>Writing standard</h3>
+<p>
+The writing should feel like a builder explaining what he noticed while mapping the ecosystem, not like a generated announcement feed.
+</p>
+<h3>Reader action</h3>
+<p>
+A good ending should push the reader toward inspection: open the source, read the setup path, check the permissions, and decide whether the workflow fits.
+</p>
+<h3>Public copy</h3>
+<p>
+Public copy should stay neutral. Say what exists, where it lives, and why it may matter. Do not turn every source into a launch announcement.
+</p>
+<h3>Maintainer habit</h3>
+<p>
+For maintainers, the habit is to separate evidence from interpretation. Evidence goes in the source block. Interpretation goes in the article. Claims stay bounded.
+</p>
+<h3>Builder takeaway</h3>
+<p>
+For builders, the takeaway is to watch the shape of demand. If many resources appear around one surface, that surface is probably becoming part of the operating layer.
+</p>
+<h3>Long-term value</h3>
+<p>
+The long-term value of this blog series is not one post. It is the map that appears when all the weekly signals are read together.
+</p>
+button.addEventListener("click",function(){
+setTheme(html.getAttribute("data-theme")==="light"?"dark":"light");
+});
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Rewrites this batch of previously short timeline posts into detailed long-form OpenClaw ecosystem analysis
- Uses Rohit writing style: practical builder/operator lens, timeline note, source evidence, operational risks, and concrete takeaways
- Keeps claims bounded to public source metadata and avoids hype/internal-tool language

## Posts
- docs/blog/openclaw-rl-conversational-training.html
- docs/blog/v2026-4-25-release-cadence.html

## Test Plan
- python3 scripts/validate_static.py
- git diff --check
- line-count check: all changed posts are 500+ lines
