### PR TITLE
docs: add verified OpenClaw resource batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,8 @@ docker compose run --rm openclaw-cli security audit --deep
 | **OpenClaw-Wechat** | [GitHub](https://github.com/dingxiang-me/OpenClaw-Wechat) | WeChat / WeCom credentials | Chinese WeChat and Enterprise WeChat integration with streaming output and visual configuration docs |
 | **Feishu Guide** | [GitHub](https://github.com/AlexAnys/openclaw-feishu) | Lark / Feishu app credentials | Community Feishu and Lark setup guide covering webhook and WebSocket channel patterns |
 | **Tencent WeChat Plugin** | [GitHub](https://github.com/Tencent/openclaw-weixin) | WeChat login | WeChat channel plugin for OpenClaw with QR-code login authorization and version compatibility notes |
+| **Telegram Task Silencer** | [GitHub](https://github.com/adagues/openclaw-telegram-task-silencer) | Telegram bot token | OpenClaw plugin that suppresses Telegram background-task completion notifications without changing the task registry |
+| **Customer Bridge** | [GitHub](https://github.com/gthneo/openclaw-customer-bridge) | WeChat / WeCom credentials | OpenClaw plugin for mapping customer identity across personal WeChat, WeCom, and WeChat Open Platform identifiers |
 
 ### Local LLM Integration
 
@@ -935,6 +937,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Admin](https://github.com/itq5/OpenClaw-Admin)** | Admin console | Vue-based web console for OpenClaw Gateway agents, sessions, models, channels, skills, and terminal access |
 | **[Autensa Mission Control](https://github.com/crshdn/mission-control)** | Product workflow console | Self-hosted OpenClaw Gateway product-engine workflow for market research, feature generation, PR creation, and run visibility |
 | **[TenacitOS](https://github.com/carlosazaustre/tenacitOS)** | Local dashboard | Next.js control center that reads OpenClaw agents, sessions, memory, logs, cron jobs, costs, and workspace files from the local installation. |
+| **[Monitoring OpenClaw](https://github.com/vincentlefort/monitoring-openclaw)** | Community dashboard | Dashboard for an OpenClaw infrastructure stack with service status, trading bot status, recent trades, and capital history views |
 
 ### Backup & Restore
 
@@ -951,6 +954,7 @@ tar -czvf ~/openclaw_backup_$(date +%Y%m%d).tar.gz -C "$HOME" .openclaw
 - [Keep My Claw](https://keepmyclaw.com) - Encrypted OpenClaw backup and restore service with client-side encryption, scheduled snapshots, and Cloudflare R2 storage.
 - [soul-upload.com](https://soul-upload.com) - Encrypted backup storage for OpenClaw workspace artifacts, using local encryption before upload and recovery by URL plus password.
 - [openclaw-backup](https://github.com/LeoYeAI/openclaw-backup) - Backup and restore skill for OpenClaw instance migration. Review credential scope before use.
+- [openclaw-infra](https://github.com/basi163/openclaw-infra) - Disaster-recovery bootstrap for exporting OpenClaw settings, versioning infrastructure state, and restoring a server profile.
 
 ---
 
@@ -1115,6 +1119,16 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **AutoResearchClaw** | Research workflow project for idea-to-paper agents using OpenClaw and MetaClaw patterns | [GitHub](https://github.com/aiming-lab/AutoResearchClaw) |
 | **memU** | Memory layer for long-running proactive agents such as OpenClaw, with a Python package and public docs | [GitHub](https://github.com/NevaMind-AI/memU) |
 | **Sundial Awesome OpenClaw Skills** | Curated OpenClaw skill collection organized by category with an install command for `sundial-hub` users | [GitHub](https://github.com/sundial-org/awesome-openclaw-skills) |
+| **OpenClaw Plugin Inspector** | Offline compatibility checker for OpenClaw plugin packages, manifests, hooks, registration calls, and CI artifacts | [GitHub](https://github.com/openclaw/plugin-inspector) |
+| **OpenClaw Kitchen Sink Plugin** | Credential-free fixture plugin that covers public OpenClaw plugin API surfaces for examples and compatibility testing | [GitHub](https://github.com/openclaw/kitchen-sink) |
+| **crabpot** | Compatibility testbed that pins community plugins and checks OpenClaw plugin API seams with plugin-inspector | [GitHub](https://github.com/openclaw/crabpot) |
+| **ClawBio** | Bioinformatics-native OpenClaw skill library with local-first workflows and installable skills for research tasks | [GitHub](https://github.com/ClawBio/ClawBio) |
+| **OpenClaw Materials Lab** | Native OpenClaw plugin for materials-science search, structure analysis, candidate comparison, notes, and report export | [GitHub](https://github.com/cranesun1226/openclaw-materials-lab) |
+| **Skysearch** | Flight-search skill for OpenClaw that uses browser automation across booking and airline sites without requiring API keys | [GitHub](https://github.com/Steve-reyes/Skysearch) |
+| **OpenClaw Documentation Skill** | Auto-syncing documentation skill that gives coding assistants installable OpenClaw reference material and workflows | [GitHub](https://github.com/tbdavid2019/openclaw-docs-skill) |
+| **OpenClaw Offline Seed** | Config-driven offline plugin and skill seeding tool for OpenClaw runtimes on Kubernetes, Helm, and Docker | [GitHub](https://github.com/weak-fox/openclaw-offline-seed) |
+| **AxonHub OpenClaw Plugin** | Provider plugin that routes OpenClaw model requests through a self-hosted or hosted AxonHub AI gateway | [GitHub](https://github.com/Ruelya/axonhub-openclaw-plugin) |
+| **Remnic** | Local-first memory plugin for OpenClaw-compatible agents that stores extracted memory as plain Markdown with search support | [GitHub](https://github.com/joshuaswarren/remnic) |
 
 ### Third-Party Platforms
 
@@ -1139,6 +1153,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **[clawport-ui](https://github.com/JohnRiceML/clawport-ui)** | Command center | Open-source command center for OpenClaw-backed coding agent teams |
 | **[Star Office UI](https://github.com/ringhyacinth/Star-Office-UI)** | Visual office | Pixel-office interface for showing OpenClaw work states, daily notes, and guest agents |
 | **[AlphaClaw](https://github.com/chrysb/alphaclaw)** | Setup harness | Setup UI and watchdog harness for deploying and keeping OpenClaw instances running |
+| **[OpenClaw Skills Explorer](https://github.com/Cluka-399/openclaw-skills-explorer)** | Skill browser | Static skill discovery interface for browsing, categorizing, and copying OpenClaw skill install commands |
 
 ### Install a Skill
 

--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -178,7 +178,7 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <h1>Built with <span class="hl">OpenClaw</span></h1>
 <p>Curated directory of projects, tools, apps, plugins, use-case collections, and integration resources in the OpenClaw ecosystem.</p>
 <div class="hero-stats">
-<div class="hero-stat"><div class="val">148+</div><div class="lbl">Resources</div></div>
+<div class="hero-stat"><div class="val">158+</div><div class="lbl">Resources</div></div>
 <div class="hero-stat"><div class="val">195K+</div><div class="lbl">Stars</div></div>
 <div class="hero-stat"><div class="val">5,700+</div><div class="lbl">Skills</div></div>
 <div class="hero-stat"><div class="val">1.6M</div><div class="lbl">Moltbook Agents</div></div>
@@ -2366,6 +2366,76 @@ body{font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg)
 <div class="card" data-cat="infra" data-tier="b"><div class="card-tier b">B</div><div class="card-header"><div class="card-icon">&#128202;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/carlosazaustre/tenacitOS" target="_blank" rel="noopener">TenacitOS</a></div><div class="card-author">by @carlosazaustre</div></div></div><div class="card-desc">Next.js control center that reads OpenClaw agents, sessions, memory, logs, cron jobs, costs, and workspace files from the local installation.</div><div class="card-meta"><span class="card-tag">Dashboard</span><span class="card-tag">Operations</span><a href="https://github.com/carlosazaustre/tenacitOS" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div></div>
 <div class="card" data-cat="hardware" data-tier="b"><div class="card-tier b">B</div><div class="card-header"><div class="card-icon">&#127932;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/sebastianvkl/pizero-openclaw" target="_blank" rel="noopener">pizero-openclaw</a></div><div class="card-author">by @sebastianvkl</div></div></div><div class="card-desc">Raspberry Pi Zero voice assistant that streams transcribed speech through an OpenClaw gateway and renders responses on a PiSugar WhisPlay LCD.</div><div class="card-meta"><span class="card-tag">Hardware</span><span class="card-tag">Voice</span><a href="https://github.com/sebastianvkl/pizero-openclaw" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div></div>
 <div class="card" data-cat="devtools" data-tier="b"><div class="card-tier b">B</div><div class="card-header"><div class="card-icon">&#128214;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/czl9707/build-your-own-openclaw" target="_blank" rel="noopener">Build Your Own OpenClaw</a></div><div class="card-author">by @czl9707</div></div></div><div class="card-desc">Step-by-step tutorial with runnable code for building an OpenClaw-style agent across chat, tools, skills, channels, cron, routing, and memory.</div><div class="card-meta"><span class="card-tag">Tutorial</span><span class="card-tag">Runnable Code</span><a href="https://github.com/czl9707/build-your-own-openclaw" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div></div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128300;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/openclaw/plugin-inspector" target="_blank" rel="noopener">OpenClaw Plugin Inspector</a></div><div class="card-author">by openclaw</div></div></div>
+<div class="card-desc">Offline compatibility checker for OpenClaw plugin packages, manifests, hooks, registration calls, and CI artifacts.</div>
+<div class="card-meta"><span class="card-tag">Plugin QA</span><span class="card-tag">CI</span><a href="https://github.com/openclaw/plugin-inspector" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129533;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/openclaw/kitchen-sink" target="_blank" rel="noopener">OpenClaw Kitchen Sink</a></div><div class="card-author">by openclaw</div></div></div>
+<div class="card-desc">Credential-free fixture plugin that exercises public OpenClaw plugin API surfaces for examples and compatibility testing.</div>
+<div class="card-meta"><span class="card-tag">Fixture</span><span class="card-tag">Plugin API</span><a href="https://github.com/openclaw/kitchen-sink" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129408;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/openclaw/crabpot" target="_blank" rel="noopener">crabpot</a></div><div class="card-author">by openclaw</div></div></div>
+<div class="card-desc">Compatibility testbed that pins community plugins and checks OpenClaw plugin API seams with plugin-inspector.</div>
+<div class="card-meta"><span class="card-tag">Compatibility</span><span class="card-tag">Plugins</span><a href="https://github.com/openclaw/crabpot" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129438;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/ClawBio/ClawBio" target="_blank" rel="noopener">ClawBio</a></div><div class="card-author">by ClawBio</div></div></div>
+<div class="card-desc">Bioinformatics-native OpenClaw skill library with local-first workflows and installable skills for research tasks.</div>
+<div class="card-meta"><span class="card-tag">Research</span><span class="card-tag">Skills</span><a href="https://github.com/ClawBio/ClawBio" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129514;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/cranesun1226/openclaw-materials-lab" target="_blank" rel="noopener">OpenClaw Materials Lab</a></div><div class="card-author">by @cranesun1226</div></div></div>
+<div class="card-desc">Native OpenClaw plugin for materials-science search, structure analysis, candidate comparison, notes, and report export.</div>
+<div class="card-meta"><span class="card-tag">Materials</span><span class="card-tag">Research</span><a href="https://github.com/cranesun1226/openclaw-materials-lab" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="automation" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#9992;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/Steve-reyes/Skysearch" target="_blank" rel="noopener">Skysearch</a></div><div class="card-author">by @Steve-reyes</div></div></div>
+<div class="card-desc">Flight-search skill for OpenClaw that uses browser automation across booking and airline sites without requiring API keys.</div>
+<div class="card-meta"><span class="card-tag">Travel</span><span class="card-tag">Browser Automation</span><a href="https://github.com/Steve-reyes/Skysearch" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128230;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/weak-fox/openclaw-offline-seed" target="_blank" rel="noopener">OpenClaw Offline Seed</a></div><div class="card-author">by @weak-fox</div></div></div>
+<div class="card-desc">Config-driven offline plugin and skill seeding tool for OpenClaw runtimes on Kubernetes, Helm, and Docker.</div>
+<div class="card-meta"><span class="card-tag">Deployment</span><span class="card-tag">Skills</span><a href="https://github.com/weak-fox/openclaw-offline-seed" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="memory" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129504;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/joshuaswarren/remnic" target="_blank" rel="noopener">Remnic</a></div><div class="card-author">by @joshuaswarren</div></div></div>
+<div class="card-desc">Local-first memory plugin for OpenClaw-compatible agents that stores extracted memory as plain Markdown with search support.</div>
+<div class="card-meta"><span class="card-tag">Memory</span><span class="card-tag">Local-first</span><a href="https://github.com/joshuaswarren/remnic" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128202;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/vincentlefort/monitoring-openclaw" target="_blank" rel="noopener">Monitoring OpenClaw</a></div><div class="card-author">by @vincentlefort</div></div></div>
+<div class="card-desc">Dashboard for an OpenClaw infrastructure stack with service status, recent trades, and capital history views.</div>
+<div class="card-meta"><span class="card-tag">Dashboard</span><span class="card-tag">Monitoring</span><a href="https://github.com/vincentlefort/monitoring-openclaw" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128269;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/Cluka-399/openclaw-skills-explorer" target="_blank" rel="noopener">OpenClaw Skills Explorer</a></div><div class="card-author">by @Cluka-399</div></div></div>
+<div class="card-desc">Static skill discovery interface for browsing, categorizing, and copying OpenClaw skill install commands.</div>
+<div class="card-meta"><span class="card-tag">Skill Browser</span><span class="card-tag">Discovery</span><a href="https://github.com/Cluka-399/openclaw-skills-explorer" class="card-link" target="_blank" rel="noopener">GitHub &rarr;</a></div>
+</div>
 
 </div>
 


### PR DESCRIPTION
## Summary
- Add 15 verified OpenClaw resources across channel plugins, plugin compatibility tooling, skills, research plugins, monitoring, backup/recovery, memory, and skill discovery.
- Add 10 matching directory cards and update the directory resource count to 158+.
- Preserve the comprehensive README awesome-list structure by appending entries to existing sections.

## Verification
- Checked each source via public GitHub metadata and README evidence before inclusion.
- Did not add unverified marketing pages, risky social automation items, or unsupported pricing/adoption claims.
- Public copy avoids internal assistant/tool names and em dashes.

## Test Plan
- [x] `python3 scripts/validate_static.py`
- [x] `git diff --check HEAD~1..HEAD`
- [x] Changed-file scan for internal names, secrets, and em dashes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Telegram Task Silencer and Customer Bridge entries to messaging-channel plugin docs.
  * Added many new developer tools and plugins to the directory and Third‑Party Platforms browser, including plugin inspectors, tooling, materials/biology labs, search utilities, and an offline seed.
  * Added a Monitoring dashboard link and a disaster-recovery/bootstrap entry.
  * Updated total resources count from 148+ to 158+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->