### PR TITLE
Add agenttrace to monitoring dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Admin](https://github.com/itq5/OpenClaw-Admin)** | Admin console | Vue-based web console for OpenClaw Gateway agents, sessions, models, channels, skills, and terminal access |
 | **[Autensa Mission Control](https://github.com/crshdn/mission-control)** | Product workflow console | Self-hosted OpenClaw Gateway product-engine workflow for market research, feature generation, PR creation, and run visibility |
 | **[TenacitOS](https://github.com/carlosazaustre/tenacitOS)** | Local dashboard | Next.js control center that reads OpenClaw agents, sessions, memory, logs, cron jobs, costs, and workspace files from the local installation. |
+| **[agenttrace](https://github.com/luoyuctl/agenttrace)** | Local TUI | Local-first session inspector for OpenClaw-style and other AI coding-agent logs, showing tokens, estimated cost, tool failures, latency, health, diffs, and CI gates |
 
 ### Backup & Restore
 


### PR DESCRIPTION
## Summary
- add agenttrace to the Monitoring & Dashboards section
- describe it as a local TUI for inspecting OpenClaw-style and other AI coding-agent session logs

## Validation
- git diff --check
- python3 scripts/validate_static.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agenttrace reference to the Monitoring & Dashboards section. Agenttrace is a local-first terminal user interface tool for inspecting and analyzing agent logs, providing comprehensive visibility into token consumption, estimated costs, tool failures, latency performance metrics, system health status, code diffs, and continuous integration gate compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->