### PR TITLE
Add private Telegram assistant starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1325,6 +1325,7 @@ Current OpenClaw operations include OpenTelemetry, Prometheus, dashboards, model
 - [OpenClaw 101](https://github.com/mengjian-github/openclaw101) - Chinese OpenClaw resource site with a seven-day learning path, resource index, and setup guidance.
 - [OpenClaw Chinese Docs](https://github.com/yeuxuan/openclaw-docs) - Chinese documentation site covering installation, source walkthroughs, Gateway configuration, and multi-channel setup.
 - [OpenClaw Runbook](https://github.com/digitalknk/openclaw-runbook) - Practical operations runbook for running OpenClaw with cost control, memory boundaries, coordinator/worker roles, and guardrails.
+- [OpenClaw Personal Agent Starter Free](https://github.com/rbezumoff/openclaw-personal-agent-starter-free) - Free starter path for building a private Telegram assistant with OpenClaw, including a Telegram setup checklist and starter AGENTS.md/SOUL.md workspace files.
 - [OpenClaw Course](https://github.com/kiankyars/openclawcourse) - One-hour crash course with a public lesson index for learning OpenClaw basics.
 - [Build Your Own OpenClaw](https://github.com/czl9707/build-your-own-openclaw) - Step-by-step tutorial with runnable code that builds a lightweight OpenClaw-style agent across chat, tools, skills, channels, cron, multi-agent routing, and memory.
 - [Awesome OpenClaw Tutorial](https://github.com/xianyu110/awesome-openclaw-tutorial) - Chinese OpenClaw tutorial repository with installation, configuration, current-version notes, and scenario walkthroughs.


### PR DESCRIPTION
Hi — I added a small free starter repo to the Getting Started guides.

It is for people who want to try OpenClaw as a private Telegram assistant without changing every setup layer at once. The repo has a starter path, a Telegram setup checklist, and basic AGENTS.md / SOUL.md workspace files.

I kept the description short and linked the free GitHub repo, not the paid landing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new tutorial entry "OpenClaw Personal Agent Starter Free" under Getting Started guides. This resource provides a free starter path for creating a private Telegram assistant, featuring GitHub repository access with pre-configured workspace files and step-by-step setup checklists for quick deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->