### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ docker compose run --rm openclaw-cli security audit --deep
 
 | Tool | Description | Source |
 |------|-------------|--------|
+| [APort Agent Guardrails](https://aport.io) | Pre-action authorization guardrails for AI agents and MCP/tool-use workflows. | Runtime authorization guardrails |
 | **ClawSec** | Complete security skill suite by Prompt Security | [GitHub](https://github.com/prompt-security/clawsec) |
 | **ClawBands** | Security middleware - intercepts tool execution, human-in-the-loop approval for dangerous actions | [GitHub](https://github.com/SeyZ/clawbands) |
 | **ClawGuard** | Permission manifests, runtime enforcement, sandboxing, audit logging with hash-chaining | [GitHub](https://github.com/newtro/ClawGuard) |


### PR DESCRIPTION
## Summary
- Add APort Agent Guardrails to the relevant security/tools section.
- APort provides pre-action authorization guardrails for AI agents and MCP/tool-use workflows.

## Verification
- README duplicate check
- https://aport.io link checked

## Bounty
- Related bounty: https://github.com/aporthq/aport-integrations/issues/19
- Payout: PayPal https://paypal.me/Jeremytsangchina
- Backup: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added APort Agent Guardrails to the Security Tools reference, featuring pre-action authorization guardrails for AI agents and MCP/tool-use workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-openclaw/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->