### PR TITLE
Add llm-prices to Cost Calculator & Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1911,6 +1911,7 @@ node --version                     # Must be 22+
 - [eesel.ai Pricing Guide](https://www.eesel.ai/blog/openclaw-ai-pricing)
 - [Deploy Cost Guide: $0-8/month](https://yu-wenhao.com/en/blog/2026-02-01-openclaw-deploy-cost-guide/)
 - [Cost Governor](https://github.com/AtlasPA/openclaw-cost-governor) - First OpenClaw skill with x402 agent payments. Track LLM costs in real-time, enforce budget limits with circuit breakers, enable AI agents to autonomously pay for Pro features (0.5 USDT/month).
+- [llm-prices](https://github.com/benbencodes/llm-prices) - CLI and Python library to compare LLM API costs across 273 models and 44 providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, xAI, and more). Zero-dependency, no API key required — run  to find cheapest model for any workload.
 
 ### Monthly Budget Targets
 


### PR DESCRIPTION
## What

Adds [llm-prices](https://github.com/benbencodes/llm-prices) to the Cost Calculator & Optimization section.

## Why

This is a zero-dependency Python CLI/library that compares LLM API costs across 273 models and 44 providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, xAI, etc.). It's directly relevant to the AI Model API Costs discussion in this section — users can run:



No API key required — pricing data is baked in. Also available as an MCP server for use directly inside Claude/Cursor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new resource entry for a cost comparison library in the optimization resources section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-openclaw/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->