### PR TITLE
Add trentclaw to Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ docker compose run --rm openclaw-cli security audit --deep
 | **Security Watchdog** | Host-posture watchdog for OpenClaw with firewall, SSH, exposure, and listening-port checks | [GitHub](https://github.com/lashawrelay/security-watchdog-openclaw) |
 | **Security Agent** | Daily security posture auditor for OpenClaw hosts and hosted services with baseline comparison reports | [GitHub](https://github.com/clwdtch/openclaw-security-agent) |
 | **ReefWatch** | Host-based monitoring skill for OpenClaw machines, with local detection for auth, malware, privilege, and persistence signals | [GitHub](https://github.com/yasnaak/reefwatch) |
+| **trentclaw** | Security assessment skill for OpenClaw - scans gateway config, tool permissions, installed skills, and MCP servers for risks, then proposes fixes you review before applying. | [GitHub](https://github.com/trnt-ai/trent-openclaw-security-assessment) |
 
 ### Security Resources
 


### PR DESCRIPTION
Adds **trentclaw** to the Security Tools table under Security & Hardening.

trentclaw is a security assessment skill for OpenClaw. It scans a setup's gateway config, tool permissions, installed skills, and MCP servers for risks, then proposes fixes the user reviews before applying. 

- Repo: https://github.com/trnt-ai/trent-openclaw-security-assessment
- website: https://trent.ai/

- Install: `openclaw skills install trentclaw`

- Added as the last row of the Security Tools table, per CONTRIBUTING.md
- Single resource in this PR

Happy to adjust the description or drop the entry if it's not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new Security Tools entry to the README documenting a gateway configuration and risk assessment tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-openclaw/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->