### PR TITLE
docs: add daily OpenClaw resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,8 @@ Full suite access: Gmail, Calendar, Drive, Docs, Sheets. All data stays local - 
 - [Cron Jobs Docs](https://docs.openclaw.ai/automation/cron-jobs)
 - [Heartbeat Docs](https://docs.openclaw.ai/gateway/heartbeat)
 - **[ClawTick](https://clawtick.com/)** - Cloud scheduler for OpenClaw agents with performance monitoring and uptime checks.
+- [Send to OpenClaw](https://github.com/Nateliason/send-to-openclaw) - Chrome extension and local webhook server for sending page content or selected text into a Clawdbot session.
+- [clawhip](https://github.com/Yeachan-Heo/clawhip) - Event-to-channel notification router for OpenClaw-related workflows that keeps alerts out of gateway chat sessions.
 
 ### Live Canvas
 
@@ -1505,6 +1507,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 - [clawdbot-docker](https://github.com/CrocSwap/clawdbot-docker) - Docker Compose runtime for running Clawdbot or OpenClaw with persistent storage, configurable environment variables, and container isolation.
 - [openclaw-fly-template](https://github.com/kentcdodds/flying-jarvis) - Fly.io deployment template with persistent volume, GitHub Actions deploys, Cloudflare Tunnel, and an operations runbook.
 - [lobsterd](https://github.com/tsconfigdotjson/lobsterd) - Firecracker MicroVM tenant orchestrator that can launch isolated guests with an OpenClaw gateway in each VM.
+- [clawdinators](https://github.com/openclaw/clawdinators) - Declarative NixOS-on-AWS reference for OpenClaw maintainer hosts and image-based provisioning.
 
 ### Third-Party Platforms
 
@@ -1551,6 +1554,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **[OpenClaw Kubernetes Operator](https://github.com/openclaw-rocks/openclaw-operator)** | Kubernetes operator | Operator for deploying and managing OpenClaw agent instances on Kubernetes with lifecycle, isolation, storage, and observability controls |
 | **[ClawHub CLI](https://www.npmjs.com/package/clawhub)** | Skill registry CLI | CLI for installing, updating, searching, and publishing skills and OpenClaw packages |
 | **[OpenClaw Plugin Inspector](https://www.npmjs.com/package/@openclaw/plugin-inspector)** | Compatibility checker | Offline compatibility checker for OpenClaw plugin packages and fixture suites |
+| **[OpenClaw Composio](https://github.com/ComposioHQ/openclaw-composio)** | Tool-auth fork | OpenClaw fork with an integrated Composio plugin for tool authentication and provider setup experiments |
 | **[OpenClaw Docker Sync](https://github.com/dr34m-cn/openclaw-docker)** | Docker image sync | GitHub Actions based sync from the official OpenClaw container image to Docker Hub |
 | **[OpenClaw Lark Multi-Agent](https://github.com/hackerphysics/openclaw-lark-multi-agent)** | Lark bridge | Multi-bot Lark/Feishu bridge that routes bot identities to OpenClaw Gateway sessions with isolated conversation state |
 | **[OpenClaw Dashboard Live Data](https://github.com/natanaelhx/openclaw-dashboard-live-data)** | Dashboard data feed | JSON data feed repository for an OpenClaw Vercel dashboard |
@@ -1839,6 +1843,7 @@ Current OpenClaw operations include OpenTelemetry, Prometheus, dashboards, model
 - [OpenClaw Security Practice Guide](https://github.com/slowmist/openclaw-security-practice-guide) - Agent-facing security practice guide for OpenClaw deployments.
 - [openclaw-guardian](https://github.com/LeoYeAI/openclaw-guardian) - Watchdog and operations hardening scripts for OpenClaw Gateway with checks, rollback, snapshots, and alerts.
 - [OpenClaw Exposure Guard](https://github.com/Dragon-Lady/openclaw-exposure-guard) - Read-only local checker for OpenClaw exposure, version, and risky configuration review.
+- [byebyeclaw](https://github.com/wanikua/byebyeclaw) - Uninstall and cleanup scripts for Claw-family agents, with dry-run and keep-config modes documented before destructive cleanup.
 
 ### X/Twitter Community Guides
 

--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -1353,6 +1353,20 @@ html,body{width:100%;max-width:100%;overflow-x:hidden}
 </div>
 </div>
 
+<div class="card" data-cat="automation" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128279;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/Nateliason/send-to-openclaw" target="_blank" rel="noopener">Send to OpenClaw</a></div><div class="card-author">by Nat Eliason</div></div></div>
+<div class="card-desc">Chrome extension and local webhook server for sending page content or selected text into a Clawdbot session.</div>
+<div class="card-meta"><span class="card-tag">Webhook</span><span class="card-tag">Browser</span><a href="https://github.com/Nateliason/send-to-openclaw" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="automation" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128276;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/Yeachan-Heo/clawhip" target="_blank" rel="noopener">clawhip</a></div><div class="card-author">by Yeachan Heo</div></div></div>
+<div class="card-desc">Event-to-channel notification router for OpenClaw-related workflows that keeps alerts out of gateway chat sessions.</div>
+<div class="card-meta"><span class="card-tag">Notifications</span><span class="card-tag">Routing</span><a href="https://github.com/Yeachan-Heo/clawhip" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
+</div>
+
 </div>
 <h2 class="section-title" id="hardware">Hardware &amp; Smart Home</h2>
 <div class="grid">
@@ -3905,6 +3919,20 @@ html,body{width:100%;max-width:100%;overflow-x:hidden}
 <div class="card-header"><div class="card-icon">&#128421;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/tsconfigdotjson/lobsterd" target="_blank" rel="noopener">lobsterd</a></div><div class="card-author">by tsconfigdotjson</div></div></div>
 <div class="card-desc">Firecracker MicroVM tenant orchestrator that can launch isolated guests with an OpenClaw gateway in each VM.</div>
 <div class="card-meta"><span class="card-tag">MicroVM</span><span class="card-tag">Isolation</span><a href="https://github.com/tsconfigdotjson/lobsterd" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#10052;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/openclaw/clawdinators" target="_blank" rel="noopener">clawdinators</a></div><div class="card-author">by openclaw</div></div></div>
+<div class="card-desc">Declarative NixOS-on-AWS reference for OpenClaw maintainer hosts and image-based provisioning.</div>
+<div class="card-meta"><span class="card-tag">NixOS</span><span class="card-tag">AWS</span><a href="https://github.com/openclaw/clawdinators" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128295;</div><div class="card-title-wrap"><div class="card-title"><a href="https://github.com/ComposioHQ/openclaw-composio" target="_blank" rel="noopener">OpenClaw Composio</a></div><div class="card-author">by ComposioHQ</div></div></div>
+<div class="card-desc">OpenClaw fork with an integrated Composio plugin for tool authentication and provider setup experiments.</div>
+<div class="card-meta"><span class="card-tag">Plugin</span><span class="card-tag">Fork</span><a href="https://github.com/ComposioHQ/openclaw-composio" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
 </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Adds 5 verified OpenClaw resources to the existing README categories without changing the awesome-list structure.
- Adds 4 matching directory cards for webhook, notification routing, NixOS/AWS, and tool-auth fork resources.
- Kept today separate from contributor-credit merges: PR #173, PR #172, and PR #170 were merged first.

## Verified sources
- Nateliason/send-to-openclaw: Chrome extension and local webhook server for sending page content to Clawdbot.
- Yeachan-Heo/clawhip: notification router with OpenClaw install and verification docs.
- openclaw/clawdinators: OpenClaw maintainer NixOS/AWS provisioning reference.
- ComposioHQ/openclaw-composio: OpenClaw fork with integrated Composio plugin.
- wanikua/byebyeclaw: cleanup scripts with dry-run and keep-config modes documented.

## Test Plan
- `python3 scripts/validate_static.py`
- `git diff --check`
- Changed-file scan for internal tool names, em dashes, and secret placeholders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded curated resource lists with four new entries including webhooks & cron jobs, third-party platform integrations, and security utilities.
  * Added four new directory cards to the ecosystem listing covering automation and infrastructure & deployment categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->