### PR TITLE
docs: add Openmail to Email & Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ ollama pull llama3.1
 - **Apple Calendar**: Via khal/vdirsyncer integration
 - **Outlook**: Calendar sync and management
 - **[BotEmail.ai](https://botemail.ai)** - Instant @botemail.ai email inboxes for AI agents. One API call creates a dedicated inbox with no human setup required. Includes an OpenClaw skill ([ClawHub](https://clawhub.ai/skills/bot-email)), MCP server, and OpenAI GPT Actions support.
+- **[Openmail](https://openmail.sh)** - Email infrastructure for AI agents with reliable sending, receiving, and routing. Includes an OpenClaw skill ([ClawHub](https://clawhub.ai/armandokun/openmail)) for direct integration into OpenClaw-based workflows.
 
 - [Gmail Automation Guide](https://zenvanriel.nl/ai-engineer-blog/openclaw-gmail-pubsub-automation-guide/)
 - [Google Calendar Sync](https://martin.hjartmyr.se/articles/openclaw-google-calendar-sync/)


### PR DESCRIPTION
## Summary

- Adds [Openmail](https://openmail.sh) to the Email & Calendar subsection under Integrations & Features
- Placed at the end of the product entries block, after BotEmail.ai, matching the existing bold-link format
- Openmail has an existing OpenClaw skill on ClawHub ([link](https://clawhub.ai/armandokun/openmail)), confirming active ecosystem integration

## Checklist

- [x] Added to the end of the relevant section
- [x] Neutral, factual description (no marketing language)
- [x] Matches surrounding entry format exactly
- [x] `python3 scripts/validate_static.py` passes
- [x] README.md only — no other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Openmail as a new provider in the Email & Calendar section with information about its capabilities and associated OpenClaw skill integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->