### PR TITLE
Add skill: brewpage-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **Awesome OpenClaw Plugins** | Community-maintained plugin directory with inspectable plugin folders and install notes for OpenClaw users | [GitHub](https://github.com/composio-community/awesome-openclaw-plugins) |
 | **Awesome OpenClaw Skills CN** | Chinese OpenClaw skills directory organized for local model, workflow, and plugin discovery | [GitHub](https://github.com/AIPMAndy/awesome-openclaw-skills-CN) |
 | **gstack OpenClaw Skills** | OpenClaw-adapted development workflow skill suite with planning, implementation, testing, review, and release roles | [GitHub](https://github.com/AICreator-Wind/gstack-openclaw-skills) |
+| **[brewpage-publish](https://clawhub.ai/kochetkov-ma/brewpage-publish)** | Publishes HTML, Markdown, JSON, files, or multi-file sites to brewpage.app and returns a public URL | [ClawHub](https://clawhub.ai/kochetkov-ma/brewpage-publish) |
 
 ### Setup Guides & Starters
 


### PR DESCRIPTION
Adds **brewpage-publish** to the Notable Skills & Plugins table.

- ClawHub (verification): https://clawhub.ai/kochetkov-ma/brewpage-publish
- What it does: publishes HTML, Markdown, JSON, files, or multi-file sites to brewpage.app and returns a public URL.
- License: MIT-0.

Format matches existing ClawHub-sourced rows in the table (e.g. Supermemory, Before You Build, Parley). Ran `python3 scripts/validate_static.py` — all static validations passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added brewpage-publish to the Awesome OpenClaw Skills directory in README, documenting its capability to publish multiple site formats (HTML, Markdown, JSON, files, and multi-file sites) to brewpage.app and generate public URLs for each publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->