### PR TITLE
docs: add daily OpenClaw resource batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,22 @@ docker compose run --rm openclaw-cli security audit --deep
 | **OpenClaw Kakao** | [GitHub](https://github.com/tornado1014/openclaw-kakao) | KakaoTalk / bridge config | KakaoTalk bridge that routes messages through an OpenClaw Gateway. Review platform policy before enabling account automation. |
 | **clawdbot-channel-linq** | [GitHub](https://github.com/nickvasilescu/clawdbot-channel-linq) | Linq Partner API credentials | iMessage, RCS, and SMS channel for Clawdbot through the Linq Partner API, with webhook-based inbound delivery. |
 | **Relay Spine** | [GitHub](https://github.com/CzsGit/wechat-openclaw-plugin) | WeChat / webhook credentials | OpenClaw WeChat channel bridge with QR-authenticated socket sessions and encrypted webhook handling. Review platform policy before enabling account automation. |
+| **VK npm package** | [npm](https://www.npmjs.com/package/@openclaw-vk/vk) | VK community bot credentials | VKontakte channel plugin for OpenClaw using the VK Bots Long Poll API |
+| **Twilio WhatsApp Channel** | [npm](https://www.npmjs.com/package/@srinathh/openclaw-channel-twilio-whatsapp) | Twilio account and webhook config | Twilio WhatsApp channel plugin for OpenClaw with deployment notes for public HTTPS webhooks |
+| **Lansenger Channel** | [npm](https://www.npmjs.com/package/@lansenger-pm/openclaw-lansenger-channel) | Lansenger app credentials | Lansenger enterprise messaging channel plugin for OpenClaw with WebSocket inbound and HTTP outbound delivery |
+| **DingTalk Stream Package** | [npm](https://www.npmjs.com/package/@largezhou/ddingtalk) | DingTalk robot credentials | DingTalk channel package for OpenClaw using Stream mode and multi-account routing |
+| **DingClaw Package** | [npm](https://www.npmjs.com/package/@soimy/dingtalk) | DingTalk app credentials | DingTalk channel plugin for OpenClaw with documented OpenClaw version compatibility |
+| **BridgeX Channel** | [npm](https://www.npmjs.com/package/@transplane/openclaw-bridgex) | BridgeX endpoint config | BridgeX channel plugin for agent-to-agent and human-to-agent OpenClaw messaging |
+| **OpenClaw WebSocket Channel** | [npm](https://www.npmjs.com/package/@zf-tech/openclaw-websocket) | WebSocket channel config | JSON-over-WebSocket chat channel plugin for custom OpenClaw clients |
+| **MeepaChat Channel** | [npm](https://www.npmjs.com/package/@meepa/meepachat-openclaw) | MeepaChat gateway credentials | Self-hosted MeepaChat channel plugin for OpenClaw using WebSocket inbound and REST outbound paths |
+| **NIM Channel** | [npm](https://www.npmjs.com/package/@nimsuite/openclaw-nim-channel) | NetEase IM credentials | NetEase IM channel plugin for OpenClaw P2P, group, and QChat conversations |
+| **HelloAgent Channel** | [npm](https://www.npmjs.com/package/@helloagentai/openclaw) | HelloAgent relay config | Relay-backed messaging channel plugin for connecting OpenClaw assistants to HelloAgent |
+| **Friday Next Channel** | [npm](https://www.npmjs.com/package/@syengup/friday-channel-next) | Apple channel config | Friday Next Apple channel plugin for OpenClaw messaging workflows |
+| **Sider Chrome Channel** | [npm](https://www.npmjs.com/package/@hywkp/test-openclaw-sider) | Chrome extension config | Chrome channel plugin package for connecting OpenClaw through the Sider Chrome extension |
+| **WorkClaw Channel** | [npm](https://www.npmjs.com/package/@workclaw/openclaw-workclaw) | WorkClaw platform credentials | Enterprise communications channel plugin for OpenClaw workflows |
+| **Chat4000 Channel** | [npm](https://www.npmjs.com/package/@chat4000/openclaw-plugin) | Chat4000 relay config | E2E relay-based channel plugin for routing Chat4000 messages through OpenClaw |
+| **Aephix Channel** | [npm](https://www.npmjs.com/package/@fateinabox/aephix-openclaw) | Aephix chat config | Native Aephix chat channel provider for OpenClaw integrations |
+| **Xiaoyi Channel** | [npm](https://www.npmjs.com/package/@ynhcj/xiaoyi-channel) | Xiaoyi A2A config | Xiaoyi A2A protocol channel plugin for OpenClaw |
 
 ### Local LLM Integration
 
@@ -1531,6 +1547,24 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **@vulcanen/openclaw-monitor** | Real-time monitoring console package for OpenClaw runtime status and telemetry views | [npm](https://www.npmjs.com/package/@vulcanen/openclaw-monitor) |
 | **@a1hvdy/cc-openclaw** | OpenClaw bridge plugin for routing CLI assistant traffic through an OpenAI-compatible HTTP interface | [npm](https://www.npmjs.com/package/@a1hvdy/cc-openclaw) |
 | **@openclaw/voice-call** | Voice-call channel plugin for OpenClaw integrations using Twilio, Telnyx, and Plivo transports | [npm](https://www.npmjs.com/package/@openclaw/voice-call) |
+| **@persistio/openclaw-plugin** | OpenClaw-native long-term memory plugin with explicit recall and store tools backed by Persistio | [npm](https://www.npmjs.com/package/@persistio/openclaw-plugin) |
+| **@posthog/openclaw** | PostHog LLM Analytics plugin for capturing OpenClaw model-generation and tool-call telemetry | [npm](https://www.npmjs.com/package/@posthog/openclaw) |
+| **@paleo/openclaw-slack-mock** | Synthetic Slack-shaped channel plugin for automated OpenClaw test scenarios without sending live Slack messages | [npm](https://www.npmjs.com/package/@paleo/openclaw-slack-mock) |
+| **openclaw-tavily** | Tavily web tools plugin exposing search, extract, crawl, map, and research tools to OpenClaw | [npm](https://www.npmjs.com/package/openclaw-tavily) |
+| **@korveo/openclaw** | Local-first OpenClaw span exporter for viewing diagnostics from the OpenTelemetry pipeline in Korveo | [npm](https://www.npmjs.com/package/@korveo/openclaw) |
+| **@agentlas/openclaw** | Plugin package for connecting OpenClaw to Agentlas notes and knowledge-extraction workflows | [npm](https://www.npmjs.com/package/@agentlas/openclaw) |
+| **@nextclaw/openclaw-compat** | Compatibility layer for using OpenClaw plugin interfaces from NextClaw projects | [npm](https://www.npmjs.com/package/@nextclaw/openclaw-compat) |
+| **@scholai/openclaw-scholai** | Courseware plugin package for OpenClaw article-generation workflows through Scholai | [npm](https://www.npmjs.com/package/@scholai/openclaw-scholai) |
+| **@scholai/openclaw-scholai-tools** | Onboarding CLI for installing, inspecting, and updating Scholai OpenClaw plugins | [npm](https://www.npmjs.com/package/@scholai/openclaw-scholai-tools) |
+| **@listenai/openclaw-xiaoling** | Xiaoling AI plugin package for OpenClaw voice and assistant workflows | [npm](https://www.npmjs.com/package/@listenai/openclaw-xiaoling) |
+| **@a5c-ai/hooks-mux-adapter-openclaw** | Harness adapter that connects OpenClaw to the hooks-mux system | [npm](https://www.npmjs.com/package/@a5c-ai/hooks-mux-adapter-openclaw) |
+| **@agent-vm/openclaw-gateway** | Package for running the OpenClaw gateway lifecycle inside an Agent VM environment | [npm](https://www.npmjs.com/package/@agent-vm/openclaw-gateway) |
+| **@alfe.ai/openclaw-sync** | Backup and sync skill for OpenClaw agent workspaces | [npm](https://www.npmjs.com/package/@alfe.ai/openclaw-sync) |
+| **openclaw-webchat-server** | Browser WebSocket relay server for connecting webchat users to OpenClaw agents | [npm](https://www.npmjs.com/package/openclaw-webchat-server) |
+| **@riddledc/openclaw-riddledc** | OpenClaw integration package for RiddleDC workflows with no-secrets setup notes | [npm](https://www.npmjs.com/package/@riddledc/openclaw-riddledc) |
+| **@onequery/openclaw-plugin** | OneQuery plugin package for OpenClaw workflows | [npm](https://www.npmjs.com/package/@onequery/openclaw-plugin) |
+| **@parall/openclaw-agent** | Bootstrap wrapper that prepares per-agent OpenClaw state before launching Parall agents | [npm](https://www.npmjs.com/package/@parall/openclaw-agent) |
+| **@watchline/openclaw-plugin** | Delivery adapter for receiving matched Watchline events in OpenClaw workflows | [npm](https://www.npmjs.com/package/@watchline/openclaw-plugin) |
 | **EQVPS** | API-native, pay-per-use VPS skill for OpenClaw with MCP tools for listing plans, ordering servers after confirmation, power control, reinstall, hostname updates, and cancellation. | [ClawHub](https://clawhub.ai/poiuyhje/eqvps) |
 
 ### Setup Guides & Starters

--- a/docs/daily-resource-curation-2026-06-11.md
+++ b/docs/daily-resource-curation-2026-06-11.md
@@ -1,0 +1,64 @@
+# Daily resource curation, 2026-06-11
+
+This log records the public-source checks behind the 2026-06-11 Awesome OpenClaw maintenance update.
+
+## Summary
+
+- Open contributor PRs reviewed: 2.
+- Verified resources added to `README.md`: 34.
+- Verified resources also added to `docs/website/directory.html`: 9.
+- Primary source type: npm registry package metadata, npm package README content, and linked public GitHub repositories where available.
+- Stopping reason: the run stopped below the daily 50-60 target because remaining search results included duplicates already in the README or website, wallet/payment/on-chain items needing separate risk review, social/account automation items needing stricter platform-policy wording, deprecated shims, or packages with insufficient OpenClaw-specific README evidence.
+
+## Accepted candidates
+
+| Candidate | Type | Public evidence | Placement |
+|-----------|------|-----------------|-----------|
+| `@openclaw-vk/vk` | plugin | npm metadata and README document a VKontakte channel plugin for OpenClaw using VK Bots Long Poll API and OpenClaw version requirements. | README |
+| `@srinathh/openclaw-channel-twilio-whatsapp` | plugin | npm metadata and README document a Twilio WhatsApp channel plugin for OpenClaw with HTTPS webhook deployment notes. | README |
+| `@lansenger-pm/openclaw-lansenger-channel` | plugin | npm metadata documents a Lansenger enterprise messaging channel plugin for OpenClaw with WebSocket inbound and HTTP outbound delivery. | README |
+| `@largezhou/ddingtalk` | plugin | npm metadata and README document a DingTalk Stream-mode channel plugin for OpenClaw. | README |
+| `@soimy/dingtalk` | plugin | npm metadata and README document a DingTalk channel plugin with OpenClaw compatibility badges and setup notes. | README |
+| `@transplane/openclaw-bridgex` | plugin | npm metadata and README document a BridgeX channel plugin for OpenClaw agent-to-agent and human-to-agent messaging. | README, directory |
+| `@zf-tech/openclaw-websocket` | plugin | npm metadata and README document a JSON-over-WebSocket OpenClaw channel plugin for custom apps. | README, directory |
+| `@meepa/meepachat-openclaw` | plugin | npm metadata and README document a self-hosted MeepaChat channel plugin for OpenClaw using WebSocket inbound and REST outbound paths. | README, directory |
+| `@nimsuite/openclaw-nim-channel` | plugin | npm metadata and README document a NetEase IM channel plugin for OpenClaw P2P, group, and QChat conversations. | README |
+| `@helloagentai/openclaw` | plugin | npm metadata and README document a relay-backed HelloAgent channel plugin for OpenClaw assistants. | README |
+| `@syengup/friday-channel-next` | plugin | npm metadata documents an Apple-channel plugin for OpenClaw. | README |
+| `@hywkp/test-openclaw-sider` | plugin | npm metadata documents a Chrome channel plugin for connecting OpenClaw through Sider Chrome extension. | README |
+| `@workclaw/openclaw-workclaw` | plugin | npm metadata documents an enterprise communications channel plugin for OpenClaw. | README |
+| `@chat4000/openclaw-plugin` | plugin | npm metadata documents an E2E relay channel plugin for routing Chat4000 messages through OpenClaw. | README |
+| `@fateinabox/aephix-openclaw` | plugin | npm metadata documents an Aephix chat channel provider for OpenClaw. | README |
+| `@ynhcj/xiaoyi-channel` | plugin | npm metadata documents a Xiaoyi A2A protocol channel plugin for OpenClaw. | README |
+| `@persistio/openclaw-plugin` | memory plugin | npm metadata and README document an OpenClaw-native Persistio long-term memory plugin with recall and store tools. | README, directory |
+| `@posthog/openclaw` | monitoring dashboard | npm metadata and README document PostHog LLM Analytics for OpenClaw telemetry. | README, directory |
+| `@paleo/openclaw-slack-mock` | developer tool | npm metadata and README document a synthetic Slack-shaped OpenClaw channel plugin for tests without live Slack sends. | README, directory |
+| `openclaw-tavily` | plugin | npm metadata and README document Tavily search, extract, crawl, map, and research tools for OpenClaw. | README, directory |
+| `@korveo/openclaw` | monitoring dashboard | npm metadata and README document a local-first span exporter for OpenClaw OpenTelemetry diagnostics. | README, directory |
+| `@agentlas/openclaw` | plugin | npm metadata documents an OpenClaw plugin for Agentlas notes and knowledge-extraction workflows. | README |
+| `@nextclaw/openclaw-compat` | developer tool | npm metadata documents an OpenClaw plugin compatibility layer for NextClaw. | README |
+| `@scholai/openclaw-scholai` | plugin | npm metadata documents a Scholai courseware plugin for OpenClaw article-generation workflows. | README |
+| `@scholai/openclaw-scholai-tools` | developer tool | npm metadata documents an onboarding CLI for Scholai OpenClaw plugin install, info, doctor, and update workflows. | README |
+| `@listenai/openclaw-xiaoling` | plugin | npm metadata documents a Xiaoling AI plugin for OpenClaw. | README |
+| `@a5c-ai/hooks-mux-adapter-openclaw` | developer tool | npm metadata documents a hooks-mux harness adapter for OpenClaw. | README |
+| `@agent-vm/openclaw-gateway` | deployment template | npm metadata documents OpenClaw gateway lifecycle management inside an Agent VM. | README |
+| `@alfe.ai/openclaw-sync` | backup/restore tool | npm metadata documents a workspace backup and sync skill for OpenClaw. | README, directory |
+| `openclaw-webchat-server` | companion app | npm metadata documents a browser WebSocket relay server between webchat users and OpenClaw agents. | README |
+| `@riddledc/openclaw-riddledc` | workflow automation | npm metadata documents an OpenClaw integration package for RiddleDC with no-secrets setup notes. | README |
+| `@onequery/openclaw-plugin` | plugin | npm metadata documents a OneQuery OpenClaw plugin package. | README |
+| `@parall/openclaw-agent` | companion app | npm metadata documents a bootstrap wrapper for preparing per-agent OpenClaw state before launching Parall agents. | README |
+| `@watchline/openclaw-plugin` | workflow automation | npm metadata documents a delivery adapter for matched Watchline events in OpenClaw workflows. | README |
+
+## Contributor PR triage
+
+| PR | Classification | Decision | Reason |
+|----|----------------|----------|--------|
+| #182, TWZRD Agent Intel | resource-submission | deferred | Solana wallet, trust scoring, and x402 payment orientation needs stronger OpenClaw-specific evidence and more conservative safety wording before inclusion. |
+| #99, XVARY Stock Research | resource-submission | deferred | Claude Code-specific skill, no clear OpenClaw integration evidence, and the PR adds a new top-level README section rather than using the existing taxonomy. |
+
+## Deferred or rejected candidate classes
+
+- Wallet, identity, payment, and on-chain packages were deferred for separate security and policy review.
+- Risky social/account automation packages were deferred unless they had official API-compliant setup and conservative wording.
+- Deprecated compatibility shims were skipped when the maintained package was already listed or a better current package existed.
+- Generic adapter packages without enough OpenClaw-specific README evidence were not added.

--- a/docs/website/directory.html
+++ b/docs/website/directory.html
@@ -3935,6 +3935,69 @@ html,body{width:100%;max-width:100%;overflow-x:hidden}
 <div class="card-meta"><span class="card-tag">Plugin</span><span class="card-tag">Fork</span><a href="https://github.com/ComposioHQ/openclaw-composio" class="card-link" target="_blank" rel="noopener">View &rarr;</a></div>
 </div>
 
+<div class="card" data-cat="social" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128172;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@transplane/openclaw-bridgex" target="_blank" rel="noopener">BridgeX Channel</a></div><div class="card-author">by Transplane</div></div></div>
+<div class="card-desc">Agent-to-agent and human-to-agent messaging bridge package for OpenClaw channel workflows.</div>
+<div class="card-meta"><span class="card-tag">Channel</span><span class="card-tag">Bridge</span><a href="https://www.npmjs.com/package/@transplane/openclaw-bridgex" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128736;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@zf-tech/openclaw-websocket" target="_blank" rel="noopener">OpenClaw WebSocket Channel</a></div><div class="card-author">by zf-tech</div></div></div>
+<div class="card-desc">JSON-over-WebSocket chat channel plugin for building custom OpenClaw client surfaces.</div>
+<div class="card-meta"><span class="card-tag">WebSocket</span><span class="card-tag">Client apps</span><a href="https://www.npmjs.com/package/@zf-tech/openclaw-websocket" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="memory" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129504;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@persistio/openclaw-plugin" target="_blank" rel="noopener">Persistio OpenClaw Plugin</a></div><div class="card-author">by Persistio</div></div></div>
+<div class="card-desc">Long-term memory plugin with explicit recall and store tools for OpenClaw agents.</div>
+<div class="card-meta"><span class="card-tag">Memory</span><span class="card-tag">Recall</span><a href="https://www.npmjs.com/package/@persistio/openclaw-plugin" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128202;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@posthog/openclaw" target="_blank" rel="noopener">PostHog OpenClaw</a></div><div class="card-author">by PostHog</div></div></div>
+<div class="card-desc">LLM analytics plugin for capturing OpenClaw model-generation and tool-call telemetry.</div>
+<div class="card-meta"><span class="card-tag">Observability</span><span class="card-tag">Analytics</span><a href="https://www.npmjs.com/package/@posthog/openclaw" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128269;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/openclaw-tavily" target="_blank" rel="noopener">openclaw-tavily</a></div><div class="card-author">by framix-team</div></div></div>
+<div class="card-desc">Tavily web tools plugin exposing search, extract, crawl, map, and research tools to OpenClaw.</div>
+<div class="card-meta"><span class="card-tag">Web tools</span><span class="card-tag">Research</span><a href="https://www.npmjs.com/package/openclaw-tavily" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="infra" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128202;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@korveo/openclaw" target="_blank" rel="noopener">Korveo OpenClaw</a></div><div class="card-author">by Korveo</div></div></div>
+<div class="card-desc">Local-first OpenClaw span exporter for viewing OpenTelemetry diagnostics in Korveo.</div>
+<div class="card-meta"><span class="card-tag">Observability</span><span class="card-tag">Local</span><a href="https://www.npmjs.com/package/@korveo/openclaw" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="devtools" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#129514;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@paleo/openclaw-slack-mock" target="_blank" rel="noopener">OpenClaw Slack Mock</a></div><div class="card-author">by paleo</div></div></div>
+<div class="card-desc">Synthetic Slack-shaped channel plugin for testing OpenClaw workflows without sending live Slack messages.</div>
+<div class="card-meta"><span class="card-tag">Testing</span><span class="card-tag">Slack</span><a href="https://www.npmjs.com/package/@paleo/openclaw-slack-mock" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="social" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128172;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@meepa/meepachat-openclaw" target="_blank" rel="noopener">MeepaChat OpenClaw</a></div><div class="card-author">by MeepaChat maintainers</div></div></div>
+<div class="card-desc">Self-hosted MeepaChat channel plugin for OpenClaw using WebSocket inbound and REST outbound paths.</div>
+<div class="card-meta"><span class="card-tag">Channel</span><span class="card-tag">Self-hosted chat</span><a href="https://www.npmjs.com/package/@meepa/meepachat-openclaw" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
+<div class="card" data-cat="automation" data-tier="b">
+<div class="card-tier b">B</div>
+<div class="card-header"><div class="card-icon">&#128260;</div><div class="card-title-wrap"><div class="card-title"><a href="https://www.npmjs.com/package/@alfe.ai/openclaw-sync" target="_blank" rel="noopener">AlfeSync OpenClaw</a></div><div class="card-author">by Alfe AI</div></div></div>
+<div class="card-desc">Backup and sync skill for OpenClaw agent workspaces.</div>
+<div class="card-meta"><span class="card-tag">Backup</span><span class="card-tag">Workspace sync</span><a href="https://www.npmjs.com/package/@alfe.ai/openclaw-sync" class="card-link" target="_blank" rel="noopener">npm &rarr;</a></div>
+</div>
+
 </div>
 
 <footer class="footer">


### PR DESCRIPTION
## Summary
- add 34 verified OpenClaw npm resources to the README's existing Messaging Channels and Skills & Plugins sections
- add 9 matching resource cards to the ecosystem directory without changing the grid structure
- add a dated curation log with accepted, deferred, and contributor PR triage notes

## Validation
- python3 scripts/validate_static.py
- git diff --check HEAD~1..HEAD
- changed-file scan for internal tool names, secrets, and em dashes

## Contributor PR triage
- #182 deferred: Solana wallet/x402 trust-scoring resource needs stronger OpenClaw-specific evidence and more conservative safety wording
- #99 deferred: Claude Code-specific skill, no clear OpenClaw integration evidence, and standalone top-level README placement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded ecosystem directory with new third-party integrations across messaging channels and plugins
  * Added daily resource curation documentation log
  * Enhanced web directory with 9 new package cards for ecosystem discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->