### PR TITLE
Add DOS Kernel to Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ docker compose run --rm openclaw-cli security audit --deep
 | **Security Agent** | Daily security posture auditor for OpenClaw hosts and hosted services with baseline comparison reports | [GitHub](https://github.com/clwdtch/openclaw-security-agent) |
 | **ReefWatch** | Host-based monitoring skill for OpenClaw machines, with local detection for auth, malware, privilege, and persistence signals | [GitHub](https://github.com/yasnaak/reefwatch) |
 | **trentclaw** | Security assessment skill for OpenClaw - scans gateway config, tool permissions, installed skills, and MCP servers for risks, then proposes fixes you review before applying. | [GitHub](https://github.com/trnt-ai/trent-openclaw-security-assessment) |
+| **DOS Kernel** | Deterministic trust kernel — verifies agent "done" claims against git evidence instead of self-report, arbitrates file collisions between concurrent agents, audits commit claims vs diffs. Wire via `openclaw mcp add dos --command dos-mcp` | [GitHub](https://github.com/anthony-chaudhary/dos-kernel) |
 
 ### Security Resources
 


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to the **Security Tools** table (works with OpenClaw today via `openclaw mcp add`).

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "DOS Kernel" security resource to the Security Tools reference guide, including a direct link for quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->