### PR TITLE
Add Shieldz Payments to MCP Server Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@ ollama pull llama3.1
 | **Enhanced MCP Bridge Skill** | [GitHub](https://github.com/cc-fuyu/openclaw-mcp-bridge) | Skill that documents MCP server discovery, search, installation, and native tool calls from OpenClaw |
 | **MCP Bootstrap** | [GitHub](https://github.com/keoy7am/openclaw-mcp-bootstrap) | Bootstrap package for adding Sequential Thinking and Context7 MCP servers to OpenClaw |
 | **MCP Router** | [GitHub](https://github.com/lunarmoon26/openclaw-mcp-router) | Dynamic MCP tool router that searches large MCP catalogs before calling tools from OpenClaw |
+| **Shieldz Payments** | [GitHub](https://github.com/ShieldZCash/shieldz-openclaw) · [npm](https://www.npmjs.com/package/@shieldz/mcp) | Keyless, non-custodial crypto payment links and tip jars from just a wallet address; no API key. Remote MCP at shieldz.cash/mcp, OFAC-screened |
 
 ---
 


### PR DESCRIPTION
Adds Shieldz, a keyless MCP server that lets an OpenClaw agent accept non-custodial crypto payments (payment links + tip jars) from just a wallet address, no API key.

- Skill repo: https://github.com/ShieldZCash/shieldz-openclaw
- npm: https://www.npmjs.com/package/@shieldz/mcp
- Remote MCP endpoint: https://shieldz.cash/mcp
- Guide: https://shieldz.cash/agents

Non-custodial (funds settle straight to the wallet), OFAC-screened, rate-limited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Shieldz Payments to the MCP Server Integration list.
  * Highlighted support for keyless, non-custodial crypto payment links and tip jars.
  * Included the remote MCP endpoint and noted that no API key is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->