### PR TITLE
Add LinkedIn Skills (social-media marketing family) to Notable Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,8 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **@parall/openclaw-agent** | Bootstrap wrapper that prepares per-agent OpenClaw state before launching Parall agents | [npm](https://www.npmjs.com/package/@parall/openclaw-agent) |
 | **@watchline/openclaw-plugin** | Delivery adapter for receiving matched Watchline events in OpenClaw workflows | [npm](https://www.npmjs.com/package/@watchline/openclaw-plugin) |
 | **EQVPS** | API-native, pay-per-use VPS skill for OpenClaw with MCP tools for listing plans, ordering servers after confirmation, power control, reinstall, hostname updates, and cancellation. | [ClawHub](https://clawhub.ai/poiuyhje/eqvps) |
+| **LinkedIn Skills** | Social media marketing for 7 platforms (LinkedIn, X, Instagram, YouTube, TikTok, Threads, Facebook): corpus-validated hooks, humanizer, audience insights | [ClawHub](https://clawhub.ai/sergebulaev/linkedin-post-writer) \| [GitHub](https://github.com/sergebulaev/linkedin-skills) |
+
 
 ### Setup Guides & Starters
 


### PR DESCRIPTION
Adds a row for the social-media marketing skill family to **Notable Skills & Plugins**.

[sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills) is the flagship of a 7-platform family (LinkedIn, X, Instagram, YouTube, TikTok, Threads, Facebook), on ClawHub (https://clawhub.ai/sergebulaev/linkedin-post-writer) and as a Claude Code + Codex plugin. Hook formulas validated against real high-performing-post corpora; each ships a humanizer + audience-insights read layer. Matched the existing table format (Skill | Description | Source). MIT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added LinkedIn Skills to the list of notable skills and plugins.
  * Included links to related resources and source repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->