### PR TITLE
Add ClawBench OpenClaw benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Probe Rust](https://github.com/Edison94hu/openclaw-probe-rs)** | Host agent | Rust host probe for OpenClaw health checks, restarts, session token scanning, system metrics, and backup tasks |
 | **[clawdbot-cost-monitor](https://github.com/bokonon23/clawdbot-cost-monitor)** | Cost dashboard | Local dashboard for parsing OpenClaw session files and showing token and cost history |
 | **[Moltcraft](https://github.com/askmojo/moltcraft)** | Visual dashboard | Isometric dashboard that connects to a Moltbot or OpenClaw gateway to visualize agent activity |
-| **[ClawBench](https://github.com/reacher-z/ClawBench)** | Browser-agent benchmark | Live-website benchmark with a selectable OpenClaw harness, request-level task scoring, and five-layer run traces across 283 tasks ([project](https://claw-bench.com/)) |
+| **[ClawBench](https://github.com/reacher-z/ClawBench)** | Browser-agent benchmark | Live-website benchmark with a selectable OpenClaw harness, interception plus judge-based scoring, and five-layer run traces across 283 tasks ([project](https://claw-bench.com/)) |
 
 ### Backup & Restore
 

--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ Configure multiple agents with separate workspaces, personas, auth profiles, and
 | **[OpenClaw Probe Rust](https://github.com/Edison94hu/openclaw-probe-rs)** | Host agent | Rust host probe for OpenClaw health checks, restarts, session token scanning, system metrics, and backup tasks |
 | **[clawdbot-cost-monitor](https://github.com/bokonon23/clawdbot-cost-monitor)** | Cost dashboard | Local dashboard for parsing OpenClaw session files and showing token and cost history |
 | **[Moltcraft](https://github.com/askmojo/moltcraft)** | Visual dashboard | Isometric dashboard that connects to a Moltbot or OpenClaw gateway to visualize agent activity |
+| **[ClawBench](https://github.com/reacher-z/ClawBench)** | Browser-agent benchmark | Live-website benchmark with a selectable OpenClaw harness, request-level task scoring, and five-layer run traces across 283 tasks ([project](https://claw-bench.com/)) |
 
 ### Backup & Restore
 


### PR DESCRIPTION
## What changed

Adds one ClawBench row to the existing **Monitoring & Dashboards** resource table, at the bottom as required by the contribution guide. The entry links both the open-source repository and project page.

## Why it fits

ClawBench provides a selectable OpenClaw harness for evaluating browser agents on 283 tasks across live production websites. It records video, screenshots, HTTP traffic, browser actions, and agent messages, while request interception supplies task-success evidence without allowing the final real-world write.

- Project: https://claw-bench.com/
- Code: https://github.com/reacher-z/ClawBench
- Paper: https://arxiv.org/abs/2604.08523

## Validation

- Followed the existing three-column table format and added one factual resource.
- Ran `python3 scripts/validate_static.py`; all JSON, HTML, directory-grid, theme-logo, Vercel-rewrite, and README-anchor checks passed.
- Searched the default branch and open, closed, and merged PRs for ClawBench, `2604.08523`, and `claw-bench.com`; no duplicate was found.

Disclosure: I am a ClawBench maintainer, and I am submitting this entry in that capacity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ClawBench to the Monitoring & Dashboards resources, including a link to its project page and a description of its live browser-based benchmarking, selectable OpenClaw harness, interception/judge-based scoring, and multi-layer run traces across tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->