### PR TITLE
docs: add Hexis platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **[snipara-openclaw-install](https://www.npmjs.com/package/snipara-openclaw-install)** | MCP onboarding | Snipara onboarding wrapper for Hosted MCP and OpenClaw hooks setup |
 | **[@paleo/openclaw-discord-mock](https://www.npmjs.com/package/@paleo/openclaw-discord-mock)** | Test fixture channel | Synthetic Discord-shaped channel plugin for OpenClaw automated test scenarios |
 | **[@twsxtd/hapi-openclaw](https://www.npmjs.com/package/@twsxtd/hapi-openclaw)** | Gateway bridge | HAPI bridge plugin that maps native tools to the OpenClaw Gateway route surface |
+| **[Hexis](https://github.com/Bevel-Software/Hexis)** | Skills and context platform | Git-backed platform for skills, tools, and context for AI agents, accessible from OpenClaw through its remote MCP server |
 
 ### Install a Skill
 

--- a/README.md
+++ b/README.md
@@ -1798,7 +1798,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **[snipara-openclaw-install](https://www.npmjs.com/package/snipara-openclaw-install)** | MCP onboarding | Snipara onboarding wrapper for Hosted MCP and OpenClaw hooks setup |
 | **[@paleo/openclaw-discord-mock](https://www.npmjs.com/package/@paleo/openclaw-discord-mock)** | Test fixture channel | Synthetic Discord-shaped channel plugin for OpenClaw automated test scenarios |
 | **[@twsxtd/hapi-openclaw](https://www.npmjs.com/package/@twsxtd/hapi-openclaw)** | Gateway bridge | HAPI bridge plugin that maps native tools to the OpenClaw Gateway route surface |
-| **[Hexis](https://github.com/Bevel-Software/Hexis)** | Skills and context platform | Git-backed platform for skills, tools, and context for AI agents, accessible from OpenClaw through its remote MCP server |
+| **[Hexis](https://github.com/Bevel-Software/Hexis)** | Skills and context platform | Git-backed platform for skills, tools, and context for AI agents. OpenClaw connects to `https://demo.bevel.software/api/mcp` over Streamable HTTP and completes access through OAuth 2.1 |
 
 ### Install a Skill
 


### PR DESCRIPTION
## Summary

- Adds Hexis to the Third-Party Platforms table.
- Describes it as a Git-backed platform for skills, tools, and context for AI agents.
- Notes its verified OpenClaw access path through the built-in remote MCP server.

## Verification

- The current OpenClaw CLI recognizes the Hexis endpoint and its Streamable HTTP OAuth flow.
- `python3 scripts/validate_static.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Hexis to the Skills & Plugins resource table.
  * Included its GitHub link and remote MCP server integration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->