### PR TITLE
Add youtube-skills to Notable Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **@parall/openclaw-agent** | Bootstrap wrapper that prepares per-agent OpenClaw state before launching Parall agents | [npm](https://www.npmjs.com/package/@parall/openclaw-agent) |
 | **@watchline/openclaw-plugin** | Delivery adapter for receiving matched Watchline events in OpenClaw workflows | [npm](https://www.npmjs.com/package/@watchline/openclaw-plugin) |
 | **EQVPS** | API-native, pay-per-use VPS skill for OpenClaw with MCP tools for listing plans, ordering servers after confirmation, power control, reinstall, hostname updates, and cancellation. | [ClawHub](https://clawhub.ai/poiuyhje/eqvps) |
+| **youtube-skills** | MIT licensed agent skills for YouTube transcripts, video search, channel browsing, and playlist extraction. | [ClawHub](https://clawhub.ai/therohitdas/youtube-full) \| [GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
 
 ### Setup Guides & Starters
 


### PR DESCRIPTION
## Add Resource

**Name**: youtube-skills
**Link**: https://github.com/ZeroPointRepo/youtube-skills
**Section**: Skills & Plugins → Notable Skills & Plugins
**Description**: An MIT licensed collection of agent skills that give OpenClaw access to YouTube transcripts, video search, channel browsing and playlist extraction.

### What the entry is

`ZeroPointRepo/youtube-skills` is a public, MIT licensed repository of installable agent skills. It ships 12 skills under `skills/` (youtube-full, transcript, youtube-data, youtube-search, youtube-channels, youtube-playlist and others), each with its own `SKILL.md`. The OpenClaw builds are published on ClawHub, so the row links both:

- ClawHub: https://clawhub.ai/therohitdas/youtube-full
- GitHub: https://github.com/ZeroPointRepo/youtube-skills

Install for OpenClaw: `npx clawhub@latest install youtube-full`

### Checks

- [x] Resource is relevant to OpenClaw (skills are published on ClawHub and ship an OpenClaw build)
- [x] Links verified working (both return 200)
- [x] Description kept to one sentence
- [x] Added at the bottom of the relevant section, matching the neighbouring row format
- [x] One resource in this pull request
- [x] Only `README.md` edited, `index.html` untouched
- [x] `python3 scripts/validate_static.py` run locally and passes (JSON OK, HTML parse OK, directory card grids OK, theme logo rules OK, Vercel rewrites OK, README anchors OK)

Disclosure: I maintain ZeroPointRepo/youtube-skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `youtube-skills` resource to the Notable Skills & Plugins list.
  * Included links to its ClawHub and GitHub repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->