### PR TITLE
docs: add Univer Office plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Created by OpenClaw agent "Clawd Clawderberg" (built by Matt Schlicht, Cofounder
 | **[snipara-openclaw-install](https://www.npmjs.com/package/snipara-openclaw-install)** | MCP onboarding | Snipara onboarding wrapper for Hosted MCP and OpenClaw hooks setup |
 | **[@paleo/openclaw-discord-mock](https://www.npmjs.com/package/@paleo/openclaw-discord-mock)** | Test fixture channel | Synthetic Discord-shaped channel plugin for OpenClaw automated test scenarios |
 | **[@twsxtd/hapi-openclaw](https://www.npmjs.com/package/@twsxtd/hapi-openclaw)** | Gateway bridge | HAPI bridge plugin that maps native tools to the OpenClaw Gateway route surface |
+| **Univer Office** | Collaborative workspace plugin for creating and reviewing spreadsheets, documents, slides, boards, PDFs, and relational tables | [GitHub](https://github.com/dream-num/openclaw-univer-office) \| [ClawHub](https://clawhub.ai/dr-univer/plugins/openclaw-univer-office) |
 
 ### Install a Skill
 


### PR DESCRIPTION
## Summary

Adds Univer Office to the Notable Skills & Plugins table.

Univer Office is an Apache-2.0 OpenClaw plugin that connects agents to a collaborative Univer Workspace for creating and reviewing spreadsheets, documents, slides, boards, PDFs, and relational tables. It supports self-hosted deployment, real-time collaboration, review worktrees, and import/export workflows.

## Validation

- `python3 scripts/validate_static.py`
- `git diff --check`
- Verified public GitHub and ClawHub links

Disclosure: I am affiliated with the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Univer Office to the Third-Party Platforms list.
  - Documented support for creating and reviewing spreadsheets, documents, slides, boards, PDFs, and relational tables.
  - Included links to the GitHub repository and ClawHub plugin page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->